### PR TITLE
Fix recoil bug, lower XM25 deploy delay, remove old sounds from mines

### DIFF
--- a/lua/entities/ace_antipersonelmine/init.lua
+++ b/lua/entities/ace_antipersonelmine/init.lua
@@ -70,8 +70,6 @@ function ENT:Think()
 				local HEWeight=2	
 				local Radius = (HEWeight)^0.33*8*39.37
 
-				self:EmitSound("weapons/mortar/mortar_fire1.wav", 300, 70, 1, CHAN_WEAPON )			
-
 				ACF_HE( self:GetPos() , Vector(0,0,1) , HEWeight , HEWeight*0.5 , self:GetOwner(), nil, self) --0.5 is standard antipersonal mine
 
 				local Flash = EffectData()

--- a/lua/entities/ace_antitankmine/init.lua
+++ b/lua/entities/ace_antitankmine/init.lua
@@ -60,8 +60,6 @@ function ENT:Think()
 
 			if triggerRanger.Hit and not triggerRanger.Entity:IsPlayer() then
 
-				self:EmitSound("npc/env_headcrabcanister/explosion.wav", 1500, 80, 1, CHAN_WEAPON )			
-
 				local HEWeight=250	
 				local Radius = (HEWeight)^0.33*8*39.37
 								

--- a/lua/entities/ace_boundingmine/init.lua
+++ b/lua/entities/ace_boundingmine/init.lua
@@ -83,8 +83,6 @@ function ENT:Think()
 
 		if self.FuseTime < 0 then
 
-			self:EmitSound("weapons/mortar/mortar_fire1.wav", 500, 50, 1, CHAN_WEAPON )			
-
 			--print(self:GetOwner())
 			ACF_HE( self:GetPos() , Vector(0,0,1) , 5 , 0.1 , self:GetOwner(), nil, self) --0.5 is standard antipersonal mine
 

--- a/lua/weapons/weapon_ace_at4/shared.lua
+++ b/lua/weapons/weapon_ace_at4/shared.lua
@@ -59,7 +59,7 @@ SWEP.ViewModelFlip = false
 SWEP.ViewModel = "models/weapons/v_RPG.mdl"
 SWEP.WorldModel = "models/weapons/w_rocket_launcher.mdl"
 SWEP.HoldType = "rpg"
-SWEP.DeployDelay = 1 --Time before you can fire after deploying the weapon
+SWEP.DeployDelay = 2 --Time before you can fire after deploying the weapon
 SWEP.CSMuzzleFlashes = false
 
 

--- a/lua/weapons/weapon_ace_at4t/shared.lua
+++ b/lua/weapons/weapon_ace_at4t/shared.lua
@@ -59,7 +59,7 @@ SWEP.ViewModelFlip = false
 SWEP.ViewModel = "models/weapons/v_RPG.mdl"
 SWEP.WorldModel = "models/weapons/w_rocket_launcher.mdl"
 SWEP.HoldType = "rpg"
-SWEP.DeployDelay = 1 --Time before you can fire after deploying the weapon
+SWEP.DeployDelay = 2 --Time before you can fire after deploying the weapon
 SWEP.CSMuzzleFlashes = false
 
 

--- a/lua/weapons/weapon_ace_base/init.lua
+++ b/lua/weapons/weapon_ace_base/init.lua
@@ -16,7 +16,9 @@ function SWEP:UpdateFakeCrate(realcrate)
 end
 
 function SWEP:ACEFireBullet(Position, Direction)
-    self.BulletData.Pos = Position + Direction * 30
+    if not GetConVar("acf_gunfire"):GetBool() then return end
+
+    self.BulletData.Pos = Position
     self.BulletData.Flight = Direction * self.BulletData.MuzzleVel * 39.37
 
     self.BulletData.Owner = self:GetParent()
@@ -104,6 +106,8 @@ function SWEP:DoAmmoStatDisplay()
 end
 
 function SWEP:Equip()
+    if not self.BulletData then return end
+
     self:DoAmmoStatDisplay()
 
     self.BulletData.Filter = {self:GetOwner()}

--- a/lua/weapons/weapon_ace_base/shared.lua
+++ b/lua/weapons/weapon_ace_base/shared.lua
@@ -328,8 +328,10 @@ function SWEP:HandleRecoil()
         owner:SetEyeAngles(eyeAngles)
     end
 
-    delta = SysTime() - lastRecoilTime
+    delta = self.JustReloaded and 0 or (SysTime() - lastRecoilTime)
     lastRecoilTime = SysTime()
+
+    self.JustReloaded = false
 end
 
 function SWEP:OnThink()
@@ -362,6 +364,8 @@ end
 function SWEP:OnReload()
 end
 
+SWEP.JustReloaded = false
+
 function SWEP:Reload()
     if self:Clip1() == self.Primary.ClipSize then return end
     if self:Ammo1() == 0 then return end
@@ -388,6 +392,8 @@ function SWEP:Reload()
             self:EmitSound(self.ReloadSound)
         end
     end
+
+    self.JustReloaded = true
 end
 
 function SWEP:Deploy()

--- a/lua/weapons/weapon_ace_xm25/shared.lua
+++ b/lua/weapons/weapon_ace_xm25/shared.lua
@@ -59,7 +59,7 @@ SWEP.ViewModelFlip = false
 SWEP.ViewModel = "models/weapons/v_xm25.mdl"
 SWEP.WorldModel = "models/weapons/w_xm25.mdl"
 SWEP.HoldType = "ar2"
-SWEP.DeployDelay = 4 --Time before you can fire after deploying the weapon
+SWEP.DeployDelay = 1 --Time before you can fire after deploying the weapon
 SWEP.CSMuzzleFlashes = true
 
 SWEP.FuseDelay = 0


### PR DESCRIPTION
- View no longer jumps upwards when firing, reloading, and then immediately firing again
- XM25 deploy delay 4s -> 1s
- Mines don't play explosion sounds anymore - the HE function handles that