### PR TITLE
Fix weapon heat value lowering at different speeds on different servers

### DIFF
--- a/lua/weapons/weapon_ace_base/shared.lua
+++ b/lua/weapons/weapon_ace_base/shared.lua
@@ -311,7 +311,7 @@ local delta = engine.TickInterval()
 function SWEP:HandleRecoil()
     local delay = self.HeatReductionDelay or (1 / self.FireRate + delta)
 
-    if (IsFirstTimePredicted() or game.SinglePlayer()) and CurTime() - self.LastFired > delay then
+    if CurTime() - self.LastFired > delay then
         self.Heat = math.max(self.Heat - (self.HeatReductionRate * delta), 0)
     end
 


### PR DESCRIPTION
Should be 100% consistent now across various tickrates, and multiplayer vs singleplayer