### PR TITLE
More SWEP changes

### DIFF
--- a/lua/weapons/weapon_ace_antipersonmine/init.lua
+++ b/lua/weapons/weapon_ace_antipersonmine/init.lua
@@ -18,8 +18,6 @@ function SWEP:DoAmmoStatDisplay()
 end
 
 function SWEP:Equip()
-
-	self:GetOwner():GiveAmmo( 299, self.Primary.Ammo	, false )
 	self:DoAmmoStatDisplay()
 	self:SetNextPrimaryFire( CurTime() + self.DeployDelay )
 end

--- a/lua/weapons/weapon_ace_antipersonmine/shared.lua
+++ b/lua/weapons/weapon_ace_antipersonmine/shared.lua
@@ -36,7 +36,7 @@ SWEP.Primary.RecoilAngle	= 15
 SWEP.Primary.Cone			= 0.025
 SWEP.Primary.Delay			= 1
 SWEP.Primary.ClipSize		= 1
-SWEP.Primary.DefaultClip	= 1
+SWEP.Primary.DefaultClip	= 5
 SWEP.Primary.Automatic		= 0
 SWEP.Primary.Ammo		= "RPG_Round"
 

--- a/lua/weapons/weapon_ace_antitankmine/init.lua
+++ b/lua/weapons/weapon_ace_antitankmine/init.lua
@@ -18,8 +18,6 @@ function SWEP:DoAmmoStatDisplay()
 end
 
 function SWEP:Equip()
-
-	self:GetOwner():GiveAmmo( 299, self.Primary.Ammo	, false )
 	self:DoAmmoStatDisplay()
 	self:SetNextPrimaryFire( CurTime() + self.DeployDelay )
 end

--- a/lua/weapons/weapon_ace_antitankmine/shared.lua
+++ b/lua/weapons/weapon_ace_antitankmine/shared.lua
@@ -36,7 +36,7 @@ SWEP.Primary.RecoilAngle	= 15
 SWEP.Primary.Cone			= 0.025
 SWEP.Primary.Delay			= 6
 SWEP.Primary.ClipSize		= 1
-SWEP.Primary.DefaultClip	= 1
+SWEP.Primary.DefaultClip	= 3
 SWEP.Primary.Automatic		= 0
 SWEP.Primary.Ammo		= "RPG_Round"
 

--- a/lua/weapons/weapon_ace_aug/shared.lua
+++ b/lua/weapons/weapon_ace_aug/shared.lua
@@ -31,10 +31,10 @@ SWEP.HasScope = true --True if the weapon has a sniper-style scope
 
 --Recoil (crosshair movement) settings--
 --"Heat" is a number that represents how long you've been firing, affecting how quickly your crosshair moves upwards
---SWEP.HeatReductionRate = 75 --Heat loss per second when not firing
---SWEP.HeatReductionDelay = 0.3 --Delay after firing before beginning to reduce heat
-SWEP.HeatPerShot = 4 --Heat generated per shot
-SWEP.HeatMax = 35 --Maximum heat - determines max rate at which recoil is applied to eye angles
+SWEP.HeatReductionRate = 150 --Heat loss per second when not firing
+SWEP.HeatReductionDelay = 0.15 --Delay after firing before beginning to reduce heat
+SWEP.HeatPerShot = 5 --Heat generated per shot
+SWEP.HeatMax = 25 --Maximum heat - determines max rate at which recoil is applied to eye angles
                 --Also determines point at which random spread is at its highest intensity
                 --HeatMax divided by HeatPerShot gives you how many shots until you reach MaxSpread
 

--- a/lua/weapons/weapon_ace_base/shared.lua
+++ b/lua/weapons/weapon_ace_base/shared.lua
@@ -30,7 +30,7 @@ SWEP.HasScope = false --True if the weapon has a sniper-style scope
 
 --Recoil (crosshair movement) settings--
 --"Heat" is a number that represents how long you've been firing, affecting how quickly your crosshair moves upwards
-SWEP.HeatReductionRate = 75 --Heat loss per second when not firing
+SWEP.HeatReductionRate = 150 --Heat loss per second when not firing
 SWEP.HeatPerShot = 5 --Heat generated per shot
 SWEP.HeatMax = 30 --Maximum heat - determines max rate at which recoil is applied to eye angles
                 --Also determines point at which random spread is at its highest intensity
@@ -190,12 +190,10 @@ function SWEP:GetShootDir()
     spreadY = spreadY * degrees
 
     local shootDir = owner:GetAimVector()
-
-    --There's gotta be a nicer way to do this with more proper math, but for now this works
-    local upAxis = owner:GetAimVector():Angle():Right()
-    local sideAxis = owner:GetAimVector():Angle():Up()
-    shootDir = shootDir:RotateAroundAxis(upAxis, spreadY)
-    shootDir = shootDir:RotateAroundAxis(sideAxis, spreadX)
+    local sideAxis = shootDir:Cross(Vector(0, 0, 1)):GetNormalized()
+    local upAxis = shootDir:Cross(sideAxis):GetNormalized()
+    shootDir = shootDir:RotateAroundAxis(upAxis, spreadX)
+    shootDir = shootDir:RotateAroundAxis(sideAxis, spreadY)
 
     return shootDir
 end

--- a/lua/weapons/weapon_ace_boundingmine/init.lua
+++ b/lua/weapons/weapon_ace_boundingmine/init.lua
@@ -18,8 +18,6 @@ function SWEP:DoAmmoStatDisplay()
 end
 
 function SWEP:Equip()
-
-	self:GetOwner():GiveAmmo( 299, self.Primary.Ammo	, false )
 	self:DoAmmoStatDisplay()
 	self:SetNextPrimaryFire( CurTime() + self.DeployDelay )
 end

--- a/lua/weapons/weapon_ace_boundingmine/shared.lua
+++ b/lua/weapons/weapon_ace_boundingmine/shared.lua
@@ -36,7 +36,7 @@ SWEP.Primary.RecoilAngle	= 15
 SWEP.Primary.Cone			= 0.025
 SWEP.Primary.Delay			= 3
 SWEP.Primary.ClipSize		= 1
-SWEP.Primary.DefaultClip	= 1
+SWEP.Primary.DefaultClip	= 3
 SWEP.Primary.Automatic		= 0
 SWEP.Primary.Ammo		= "RPG_Round"
 

--- a/lua/weapons/weapon_ace_grenade/init.lua
+++ b/lua/weapons/weapon_ace_grenade/init.lua
@@ -18,8 +18,6 @@ function SWEP:DoAmmoStatDisplay()
 end
 
 function SWEP:Equip()
-
-	self:GetOwner():GiveAmmo( 99, self.Primary.Ammo	, false )
 	self:DoAmmoStatDisplay()
 	self:SetNextPrimaryFire( CurTime() + self.DeployDelay )
 end

--- a/lua/weapons/weapon_ace_grenade/shared.lua
+++ b/lua/weapons/weapon_ace_grenade/shared.lua
@@ -17,7 +17,6 @@ SWEP.ViewModel		= "models/weapons/v_eq_fraggrenade.mdl"
 SWEP.WorldModel		= "models/weapons/w_eq_fraggrenade.mdl"
 SWEP.ReloadSound	= "weapons/knife/knife_deploy1.wav"
 SWEP.HoldType		= "grenade"
-SWEP.CSMuzzleFlashes	= true
 
 
 -- Other settings
@@ -25,19 +24,14 @@ SWEP.Weight			= 10
 
 -- Weapon info
 SWEP.Purpose		= "BAD NADE!"
-SWEP.Instructions	= "Left mouse to drop mine"
+SWEP.Instructions	= "Left mouse to throw grenade"
 
 -- Primary fire settings
 SWEP.Primary.Sound			= "weapons/slam/throw.wav"
 SWEP.Primary.NumShots		= 1
-SWEP.Primary.Recoil			= 10
-SWEP.Primary.RecoilAngle	= 15
-SWEP.Primary.RecoilAngleVer	= 0.0
-SWEP.Primary.RecoilAngleHor	= 0.0
-SWEP.Primary.Cone			= 0.025
 SWEP.Primary.Delay			= 2
 SWEP.Primary.ClipSize		= 1
-SWEP.Primary.DefaultClip	= 1
+SWEP.Primary.DefaultClip	= 5
 SWEP.Primary.Automatic		= 0
 SWEP.Primary.Ammo		= "RPG_Round"
 
@@ -45,73 +39,54 @@ SWEP.Secondary.Ammo		= "none"
 SWEP.Secondary.ClipSize		= -1
 SWEP.Secondary.DefaultClip	= -1
 
-SWEP.ReloadSoundEnabled = 1
-
-SWEP.AimOffset = Vector(0,0,0)
-SWEP.InaccuracyAccumulation = 0
 SWEP.lastFire = CurTime()
-
-SWEP.MaxInaccuracyMult = 0
-SWEP.InaccuracyAccumulationRate = 0.3
-SWEP.InaccuracyDecayRate = 1
-
-SWEP.IronSights = true
-SWEP.IronSightsPos = Vector(-2, -15, 2.98)
-SWEP.ZoomPos = Vector(2,-2,2)
-SWEP.IronSightsAng = Angle(0.45, 0, 0)
-SWEP.CarrySpeedMul = 1 --WalkSpeedMult when carrying the weapon
-
-SWEP.ZoomAccuracyImprovement = 0.5 -- 0.3 means 0.7 the inaccuracy
-SWEP.ZoomRecoilImprovement = 0.2 -- 0.3 means 0.7 the recoil movement
-
-SWEP.CrouchAccuracyImprovement = 0.4 -- 0.3 means 0.7 the inaccuracy
-SWEP.CrouchRecoilImprovement = 0.2 -- 0.3 means 0.7 the recoil movement
-
-
-SWEP.Pin = true
 --
+
+function SWEP:ThrowNade(power)
+	local owner = self:GetOwner()
+
+	timer.Simple(1, function()
+		local wep = owner:GetActiveWeapon()
+		if owner:Alive() and wep:GetClass() ~= "weapon_ace_grenade" then return end
+
+		if owner:Alive() then
+			wep:EmitSound(Sound(wep.Primary.Sound), 100, 100, 1, CHAN_WEAPON)
+		else
+			power = 0
+		end
+
+		local ent = ents.Create( "ace_grenade" )
+
+		if ( IsValid( ent ) ) then
+			local aim = owner:GetAimVector()
+			ent:SetPos( owner:GetShootPos() )
+			ent:SetAngles( owner:EyeAngles() )
+			ent:Spawn()
+			ent:GetPhysicsObject():ApplyForceCenter(aim * power + owner:GetVelocity() * 5) --5 = mass of nade
+			ent:SetOwner( owner )
+		end
+	end)
+end
 
 function SWEP:PrimaryAttack()
 	if not self:CanPrimaryAttack() then return end
 	if (self:Ammo1() == 0) and (self:Clip1() == 0) then return end
 	self:SetNextPrimaryFire(CurTime() + self.Primary.Delay)
 	self:SetNextSecondaryFire(CurTime() + self.Primary.Delay)
-	self:EmitSound(Sound(self.Primary.Sound), 100, 100, 1, CHAN_WEAPON)
 
 	if CLIENT then
 		return
 	end
 
-	self.BulletData.Owner = self:GetOwner()
-	self.BulletData.Gun = self
-	self.InaccuracyAccumulation = math.Clamp(self.InaccuracyAccumulation + self.InaccuracyAccumulationRate - self.InaccuracyDecayRate * (CurTime() - self.lastFire), 1, self.MaxInaccuracyMult)
+	local owner = self:GetOwner()
 
+	self:SendWeaponAnim( ACT_VM_PULLPIN  )
+	owner:SetAnimation( PLAYER_ATTACK1 )
 
-	local Forward = self:GetOwner():EyeAngles():Forward()
-
-	local Up = self:GetOwner():EyeAngles():Up()
-
-	local ent = ents.Create( "ace_grenade" )
-
-	if ( IsValid( ent ) ) then
-
-		ent:SetPos( self:GetOwner():GetShootPos() + Forward * 32 )
-		ent:SetAngles( self:GetOwner():EyeAngles() )
-		ent:Spawn()
-		ent:GetPhysicsObject():ApplyForceCenter((Forward * 800 + Up * 100 + self:GetOwner():GetVelocity()) * 5)
-		ent:SetOwner( self:GetOwner() )
-	end
-
-	self:SendWeaponAnim( ACT_VM_THROW )
-	self:GetOwner():SetAnimation( ACT_HANDGRENADE_THROW1 )
+	self:ThrowNade(4000)
 
 	self.lastFire = CurTime()
-
-	if (self.Primary.TakeAmmoPerBullet) then
-		self:TakePrimaryAmmo(self.Primary.NumShots)
-	else
-		self:TakePrimaryAmmo(1)
-	end
+	self:TakePrimaryAmmo(1)
 
 end
 
@@ -121,59 +96,36 @@ function SWEP:SecondaryAttack()
 	if (self:Ammo1() == 0) and (self:Clip1() == 0) then return end
 	self:SetNextSecondaryFire( CurTime() + self.Primary.Delay )
 	self:SetNextPrimaryFire( CurTime() + self.Primary.Delay )
-	self:EmitSound(Sound(self.Primary.Sound), 100, 100, 1, CHAN_WEAPON )
 
 	if CLIENT then
 		return
 	end
 
-		self:SendWeaponAnim( ACT_VM_PULLPIN )
-		self:GetOwner():SetAnimation( ACT_HANDGRENADE_THROW1 )
+	self:SendWeaponAnim( ACT_VM_PULLPIN )
+	self:GetOwner():SetAnimation( ACT_HANDGRENADE_THROW1 )
 
-	self.BulletData.Owner = self:GetOwner()
-	self.BulletData.Gun = self
-	self.InaccuracyAccumulation = math.Clamp(self.InaccuracyAccumulation + self.InaccuracyAccumulationRate - self.InaccuracyDecayRate * (CurTime() - self.lastFire), 1, self.MaxInaccuracyMult)
-
-
-	local Forward = self:GetOwner():EyeAngles():Forward()
-
-	local Up = self:GetOwner():EyeAngles():Up()
-
-	local ent = ents.Create( "ace_grenade" )
-
-	if ( IsValid( ent ) ) then
-
-		ent:SetPos( self:GetOwner():GetShootPos() + Forward * 32 )
-		ent:SetAngles( self:GetOwner():EyeAngles() )
-		ent:Spawn()
-		ent:GetPhysicsObject():ApplyForceCenter((Forward * 400 - Up * 60 + self:GetOwner():GetVelocity()) * 5)
-		ent:SetOwner( self:GetOwner() )
-	end
+	local owner = self:GetOwner()
 
 	self:SendWeaponAnim( ACT_VM_PULLPIN  )
-	self:GetOwner():SetAnimation( PLAYER_ATTACK1 )
+	owner:SetAnimation( PLAYER_ATTACK1 )
+
+	self:ThrowNade(1000)
 
 	self.lastFire = CurTime()
-
-	if (self.Primary.TakeAmmoPerBullet) then
-		self:TakePrimaryAmmo(self.Primary.NumShots)
-	else
-		self:TakePrimaryAmmo(1)
-	end
+	self:TakePrimaryAmmo(1)
 
 end
 
-function SWEP:Think()	--Jumping and throwing grenades for more range is allowed and encouraged
+function SWEP:Think()
 end
 
 function SWEP:Reload()
+	if CurTime() < self.lastFire + self.Primary.Delay then return end
 
-	if self:Clip1() < self.Primary.ClipSize and self:Ammo1() > 0 and self.ReloadSoundEnabled == 1 then
+	if self:Clip1() < self.Primary.ClipSize and self:Ammo1() > 0 and self.ReloadSound then
 		self:EmitSound(Sound(self.ReloadSound))
 	end
 	self:DefaultReload(ACT_VM_DRAW )
 
---player.GetByID( 1 ):GiveAmmo( 30-self:Clip1(), "AR2", true )
-	self:Think()
 	return true
 end

--- a/lua/weapons/weapon_ace_m249saw/shared.lua
+++ b/lua/weapons/weapon_ace_m249saw/shared.lua
@@ -31,7 +31,7 @@ SWEP.HasScope = false --True if the weapon has a sniper-style scope
 
 --Recoil (crosshair movement) settings--
 --"Heat" is a number that represents how long you've been firing, affecting how quickly your crosshair moves upwards
-SWEP.HeatReductionRate = 125 --Heat loss per second when not firing
+SWEP.HeatReductionRate = 175 --Heat loss per second when not firing
 --SWEP.HeatReductionDelay = 0.3 --Delay after firing before beginning to reduce heat
 SWEP.HeatPerShot = 6 --Heat generated per shot
 SWEP.HeatMax = 50 --Maximum heat - determines max rate at which recoil is applied to eye angles

--- a/lua/weapons/weapon_ace_mac10/shared.lua
+++ b/lua/weapons/weapon_ace_mac10/shared.lua
@@ -31,7 +31,7 @@ SWEP.HasScope = false --True if the weapon has a sniper-style scope
 
 --Recoil (crosshair movement) settings--
 --"Heat" is a number that represents how long you've been firing, affecting how quickly your crosshair moves upwards
-SWEP.HeatReductionRate = 125 --Heat loss per second when not firing
+SWEP.HeatReductionRate = 200 --Heat loss per second when not firing
 --SWEP.HeatReductionDelay = 0.3 --Delay after firing before beginning to reduce heat
 SWEP.HeatPerShot = 6 --Heat generated per shot
 SWEP.HeatMax = 50 --Maximum heat - determines max rate at which recoil is applied to eye angles

--- a/lua/weapons/weapon_ace_p90/shared.lua
+++ b/lua/weapons/weapon_ace_p90/shared.lua
@@ -31,7 +31,7 @@ SWEP.HasScope = false --True if the weapon has a sniper-style scope
 
 --Recoil (crosshair movement) settings--
 --"Heat" is a number that represents how long you've been firing, affecting how quickly your crosshair moves upwards
-SWEP.HeatReductionRate = 100 --Heat loss per second when not firing
+SWEP.HeatReductionRate = 175 --Heat loss per second when not firing
 --SWEP.HeatReductionDelay = 0.3 --Delay after firing before beginning to reduce heat
 SWEP.HeatPerShot = 7 --Heat generated per shot
 SWEP.HeatMax = 40 --Maximum heat - determines max rate at which recoil is applied to eye angles

--- a/lua/weapons/weapon_ace_sg552/shared.lua
+++ b/lua/weapons/weapon_ace_sg552/shared.lua
@@ -31,10 +31,10 @@ SWEP.HasScope = true --True if the weapon has a sniper-style scope
 
 --Recoil (crosshair movement) settings--
 --"Heat" is a number that represents how long you've been firing, affecting how quickly your crosshair moves upwards
-SWEP.HeatReductionRate = 125 --Heat loss per second when not firing
---SWEP.HeatReductionDelay = 0.15 --Delay after firing before beginning to reduce heat
-SWEP.HeatPerShot = 10 --Heat generated per shot
-SWEP.HeatMax = 40 --Maximum heat - determines max rate at which recoil is applied to eye angles
+SWEP.HeatReductionRate = 150 --Heat loss per second when not firing
+SWEP.HeatReductionDelay = 0.15 --Delay after firing before beginning to reduce heat
+SWEP.HeatPerShot = 8 --Heat generated per shot
+SWEP.HeatMax = 30 --Maximum heat - determines max rate at which recoil is applied to eye angles
                 --Also determines point at which random spread is at its highest intensity
                 --HeatMax divided by HeatPerShot gives you how many shots until you reach MaxSpread
 


### PR DESCRIPTION
- Weapon spread now uses proper math
- Grenades go where you're actually aiming
- Grenades don't spawn until the throwing animation plays
- No more grenade spam
- Death while playing grenade throw animation spawns a grenade at your death position
- Recoil on some automatic weapons tweaked
- Grenades and mines now spawn with far less ammo