### PR TITLE
Convert old crew seat model to new playerstart sitting model

### DIFF
--- a/lua/entities/ace_crewseat_driver/init.lua
+++ b/lua/entities/ace_crewseat_driver/init.lua
@@ -19,7 +19,10 @@ end
 
 function ENT:Initialize()
 
-	self:SetModel( "models/vehicles/pilot_seat.mdl" )
+	if self:GetModel() == "models/vehicles/pilot_seat.mdl" then
+		self:SetPos(self:LocalToWorld(Vector(0, 15.3, -14)))
+	end
+	self:SetModel( "models/chairs_playerstart/sitpose.mdl" )
 	self:SetMoveType(MOVETYPE_VPHYSICS);
 	self:PhysicsInit(SOLID_VPHYSICS);
 	self:SetUseType(SIMPLE_USE);

--- a/lua/entities/ace_crewseat_gunner/init.lua
+++ b/lua/entities/ace_crewseat_gunner/init.lua
@@ -19,7 +19,10 @@ end
 
 function ENT:Initialize()
 
-	self:SetModel( "models/vehicles/pilot_seat.mdl" )
+	if self:GetModel() == "models/vehicles/pilot_seat.mdl" then
+		self:SetPos(self:LocalToWorld(Vector(0, 15.3, -14)))
+	end
+	self:SetModel( "models/chairs_playerstart/sitpose.mdl" )
 	self:SetMoveType(MOVETYPE_VPHYSICS);
 	self:PhysicsInit(SOLID_VPHYSICS);
 	self:SetUseType(SIMPLE_USE);

--- a/lua/entities/ace_crewseat_loader/init.lua
+++ b/lua/entities/ace_crewseat_loader/init.lua
@@ -19,7 +19,10 @@ end
 
 function ENT:Initialize()
 
-	self:SetModel( "models/vehicles/pilot_seat.mdl" )
+	if self:GetModel() == "models/vehicles/pilot_seat.mdl" then
+		self:SetPos(self:LocalToWorld(Vector(0, 15.3, -14)))
+	end
+	self:SetModel( "models/chairs_playerstart/sitpose.mdl" )
 	self:SetMoveType(MOVETYPE_VPHYSICS);
 	self:PhysicsInit(SOLID_VPHYSICS);
 	self:SetUseType(SIMPLE_USE);


### PR DESCRIPTION
Offset of coordinate center has been accounted for by offsetting the new models to place them in roughly the same position the seat would have been in.

I would recommend at some point in the future implementing legality checks for crew seats as I don't see any at the moment.