### PR TITLE
More improvements to traces, focused on proper NPC/player hitboxes

### DIFF
--- a/lua/acf/server/sv_acfballistics.lua
+++ b/lua/acf/server/sv_acfballistics.lua
@@ -180,10 +180,18 @@ do
       FlightTr.maxs     = Vector( TROffset, TROffset, TROffset )
       FlightTr.mins     = -FlightTr.maxs  
 
+      -- Table to hold temporary filter keys that should be removed after the below while loop is completed
+      if not Bullet.FilterKeysToRemove then Bullet.FilterKeysToRemove = {} end
+
+      for k, v in ipairs(Bullet.FilterKeysToRemove) do
+         table.remove(Bullet.Filter, v)
+         Bullet.FilterKeysToRemove[k] = nil
+      end
+
       FlightTr.filter   = Bullet.Filter -- any changes to bullet filter will be reflected in the trace
 
       --if trace hits clipped part of prop, add prop to trace filter and retry
-      while RetryTrace do        
+      while RetryTrace do
 
          -- Disables so we dont overloop it again
          RetryTrace        = false
@@ -214,13 +222,29 @@ do
            
          --We hit something that's not world, if it's visclipped, filter it out and retry 
            if FlightRes.HitNonWorld and ACF_CheckClips( FlightRes.Entity, FlightRes.HitPos ) then   --our shells hit the visclip as traceline, no more double bounds.
-             
-             table.insert( Bullet.Filter , FlightRes.Entity )
+
+             table.insert( Bullet.Filter, FlightRes.Entity )
              RetryTrace = true   --re-enabled for retry trace. Bullet will start as tracehull again unless other visclip is detected!
-            
+
           end
-      
-      end   
+
+         -- If we hit a player or NPC, we need to retry the trace as a TraceLine
+         -- TraceHull hits player's physics collision boxes rather than proper hitboxes, causing near miss shots to hit
+         local HitEnt = FlightRes.Entity
+         if FlightRes.HitNonWorld and (HitEnt:IsPlayer() or HitEnt:IsNPC()) then
+
+            FlightTr.output = nil
+            local PlayerHitCheck = util.LegacyTraceLine(FlightTr).Entity
+            FlightTr.output = FlightRes
+
+            if HitEnt ~= PlayerHitCheck then
+               table.insert(Bullet.Filter, HitEnt)
+               table.insert(Bullet.FilterKeysToRemove, #Bullet.Filter)
+
+               RetryTrace = true
+            end
+         end
+      end
    end
 
    function ACF_DoBulletsFlight( Index, Bullet )

--- a/lua/autorun/sh_ace_workarounds.lua
+++ b/lua/autorun/sh_ace_workarounds.lua
@@ -70,11 +70,22 @@ if not util.LegacyTraceLine then
 	util.LegacyTraceLine = util.TraceLine
 end
 
+-- Reload support
+util.TraceLine = util.LegacyTraceLine
+
 function util.TraceLine(TraceData, ...)
 	if istable(TraceData) then
 		TraceData.mins = Zero
 		TraceData.maxs = Zero
 	end
 
-	return Hull(TraceData, ...)
+	local TraceRes = Hull(TraceData, ...)
+
+	-- TraceHulls don't hit player hitboxes properly, if we hit a player, retry as a regular TraceLine
+	-- This fixes issues with SWEPs and toolgun traces hitting players when aiming near but not at them
+	if istable(TraceRes) and TraceRes.Entity and TraceRes.Entity:IsPlayer() then
+		return util.LegacyTraceLine(TraceData, ...)
+	end
+
+	return TraceRes
 end

--- a/lua/weapons/weapon_ace_base/shared.lua
+++ b/lua/weapons/weapon_ace_base/shared.lua
@@ -202,6 +202,7 @@ function SWEP:Shoot()
     local owner = self:GetOwner()
 
     if SERVER then
+        self.BulletData.Filter = {self:GetOwner()}
         self:ACEFireBullet(owner:GetShootPos() + owner:GetVelocity() * engine.TickInterval(), self:GetShootDir())
     end
 end
@@ -244,10 +245,10 @@ function SWEP:PrimaryAttack()
         if sounds then
             if SERVER then
                 ACE_NetworkedSound(owner, owner, self.Primary.Sound, self.BulletData.PropMass)
+            else
+                self:EmitSound(sounds.main.Package[math.random(#sounds.main.Package)])
             end
-
-            self:EmitSound(sounds.main.Package[math.random(#sounds.main.Package)])
-        elseif not sounds then
+        elseif not sounds and CLIENT then
             self:EmitSound(self.Primary.Sound)
         end
 


### PR DESCRIPTION
- Trace workaround now retries the trace if it hits a player, in order to allow things like toolgun traces and SWEP traces to pass through the physics collision box if they don't *actually* hit the player
- Volumetric ammo traces retry on player hits for the same reason as stated above
- Clear bullet filter on SWEPs when you fire - before, the filter would stack up entries of the player's weapon entity for some reason
- Fixed sounds playing twice on SWEPs when watching another player shooting