### PR TITLE
Fix 'attempt to call method 'ClearControls' (a nil value)'

### DIFF
--- a/lua/acf/client/cl_acfpermission.lua
+++ b/lua/acf/client/cl_acfpermission.lua
@@ -62,7 +62,8 @@ end
 
 
 function this.ClientPanel(Panel)
-	Panel:ClearControls()
+	if not IsValid(Panel) then return end
+
 	if !this.ClientCPanel then this.ClientCPanel = Panel end
 	Panel:SetName("ACF Damage Permissions")
 	

--- a/lua/acf/client/gui/cl_acfsetpermission.lua
+++ b/lua/acf/client/gui/cl_acfsetpermission.lua
@@ -186,7 +186,7 @@ end
 
 function Permissions:Update()
 
-	if list then	
+	if IsValid(list) then	
 		for id,line in pairs(list:GetLines()) do
 			if line:GetValue(1) == CurrentPermission then
 				list:GetLine(id):SetValue(2,"Yes")

--- a/lua/acf/client/gui/cl_acfsetpermission.lua
+++ b/lua/acf/client/gui/cl_acfsetpermission.lua
@@ -65,8 +65,6 @@ end
 function Menu.MakePanel(Panel)
 
 	Permissions:RequestUpdate()
-
-	Panel:ClearControls()
 	
 	if not PermissionModes then return end
 	

--- a/lua/acf/client/gui/cl_acfsetpermission.lua
+++ b/lua/acf/client/gui/cl_acfsetpermission.lua
@@ -201,17 +201,17 @@ function Permissions:Update()
 		end
 	end
 	
-	if currentMode then
+	if IsValid(currentMode) then
 		currentMode:SetText(string.format(currentModeTxt, CurrentPermission))
 		currentMode:SizeToContents()
 	end
 
-	if button then
+	if IsValid(button) then
 		button:SetEnabled( cvarstat and CPPI )
 		button2:SetEnabled( cvarstat and CPPI )
 	end
 
-	if status2 then
+	if IsValid(status2) then
 
 		condition = ""
 


### PR DESCRIPTION
The ClearControls method does not exist anywhere, and would prevent you from opening the spawn menu after running spawnmenu_reload.

Also fixed some other errors I encountered afterwards, the menu is a cursed rabbit hole to go down.