### PR TITLE
Offsetforce

### DIFF
--- a/lua/entities/acf_gun/init.lua
+++ b/lua/entities/acf_gun/init.lua
@@ -863,11 +863,11 @@ do
                 --nil is due to using applyforcecenter in KEShove function, so masscenter no longer required.
 
                 --local LocalPos = HasPhys and nil or self:GetPos()
-                local LocalPos = not HasPhys and self:GetPos() or nil
+                --local LocalPos = not HasPhys and self:GetPos() or nil
                 local Dir = -self:GetForward()
                 local KE = (self.BulletData.ProjMass * self.BulletData.MuzzleVel * 39.37 + self.BulletData.PropMass * 3500 * 39.37)*(GetConVarNumber("acf_recoilpush") or 1)
 
-                ACF_KEShove(self, LocalPos , Dir , KE )
+                ACF_KEShove(self, self:GetPos() , Dir , KE )
                 
                 self.Ready = false
                 self.CurrentShot = math.min(self.CurrentShot + 1, self.MagSize)

--- a/lua/entities/acf_gun/init.lua
+++ b/lua/entities/acf_gun/init.lua
@@ -857,13 +857,6 @@ do
                 self.CreateShell = ACF.RoundTypes[self.BulletData.Type].create
                 self:CreateShell( self.BulletData )
                 
-                local PhysObj = self:GetPhysicsObject()
-                local HasPhys = not self:GetParent():IsValid()  --No parented
-
-                --nil is due to using applyforcecenter in KEShove function, so masscenter no longer required.
-
-                --local LocalPos = HasPhys and nil or self:GetPos()
-                --local LocalPos = not HasPhys and self:GetPos() or nil
                 local Dir = -self:GetForward()
                 local KE = (self.BulletData.ProjMass * self.BulletData.MuzzleVel * 39.37 + self.BulletData.PropMass * 3500 * 39.37)*(GetConVarNumber("acf_recoilpush") or 1)
 


### PR DESCRIPTION
Small change to fix this problem:
https://github.com/Facepunch/garrysmod-issues/issues/5159

Moving guns, parented or otherwise, only recoil in line with their model now. No more flying off to the side...