### PR TITLE
Update init.lua to fix GLATGMs not working with optical computers

### DIFF
--- a/lua/entities/acf_glatgm/init.lua
+++ b/lua/entities/acf_glatgm/init.lua
@@ -51,13 +51,20 @@ function ENT:Initialize()
 
 	-- how far off the forward offset is for the targeting position
 	self.offsetLength = self.velocity * self.secondsOffset
+	
+	--You need to declare the CPPI owner before seeing if the optic's owner is equal to the GLATGM's owner!
+	self:CPPISetOwner(self.BulletData.Owner)
 
 	--Gets the Closest computer to spawned missile to override gun´s guidance
 	--Dont bother at using this if the table is empty
-	if not table.IsEmpty( ACE.Opticals ) then
-		for _, Optical in pairs( ACE.Opticals ) do
+	if not table.IsEmpty(ACE.Opticals) then
+		for i, Optical in pairs(ACE.Opticals) do
+			--print("Looking for computer...")
 
-			if not IsValid(Optical) then continue end
+			if not IsValid(Optical) then 
+				continue 
+
+			end
 
 			--Range: 250. Note im using squared distance. So 250 ^ 2 means distance is 250
 			if Optical:GetPos():DistToSqr(self:GetPos()) < 250 ^ 2 and Optical:CPPIGetOwner() == self:CPPIGetOwner() then
@@ -72,9 +79,7 @@ function ENT:Initialize()
 
 
 		end
-	end
-
-	self:CPPISetOwner(self.BulletData.Owner)
+	end	
 
 	--Rocket Trail effect
 	timer.Simple(0.1,function() ParticleEffectAttach("Rocket_Smoke_Trail",4, self,1)  end)


### PR DESCRIPTION
Hello! I was able to fix GLATGMs not working with optical computers. The only issue was that the owner was not being declared prior to checking if the owner of the optical computer matched the owner of the GLATGM entity; it was being declared afterwards.