### PR TITLE
Cleaned up, rebalanced, and fixed armor.

### DIFF
--- a/lua/acf/shared/armor/aluminum.lua
+++ b/lua/acf/shared/armor/aluminum.lua
@@ -4,18 +4,18 @@ local Material		= {}
 Material.id			= "Alum"
 Material.name		= "Aluminum"
 Material.sname		= "Aluminum"
-Material.desc		= "The aluminum is normally used by AFVs or light constructions, due to its low cost and realible armor effectiveness, but its extremely vulnerable to spalling and its really worthless for heavy applications."
+Material.desc		= "Aluminum is normally used by AFVs or light constructions, due to the fact it provides more protection for its weight, but is harder to use at high thicknesses making it worthless for heavy applications and is vulnerable to HEAT and creating spalling."
 Material.year		= 1955
 
 Material.massMod		= 0.221
 Material.curve		= 0.93
 
 Material.effectiveness  = 0.34
-Material.resiliance	= 0.95
-Material.HEATMul		= 80
+Material.resiliance	= 1.05
+Material.HEATMul		= 5 --Originally 80. Someone REALLY hated aluminum against HEAT.
 
 Material.spallarmor	= 1
-Material.spallresist	= 1.5
+Material.spallresist	= 1
 
 Material.spallmult	= 2
 Material.ArmorMul	= 0.334
@@ -30,30 +30,33 @@ if SERVER then
 		local effectiveness = Material.effectiveness
 		local resiliance	= Material.resiliance
 
+		local ductilityvalue = (Entity.ACF.Ductility or 0) * 1.25 --The ductility value of the armor. Outputs 1 to -1 depending on max ductility
+		local ductilitymult    = 2 / (2 - ductilityvalue * 1.5) -- Direct damage multiplier based on ductility.
+
 		armor = armor ^ curve
 		losArmor = losArmor ^ curve
 
 		local DamageModifier = 1
 
-		if Type == "Spall" then
-
-			DamageModifier = Material.spallresist
-
-		elseif Type == "HEAT" or Type == "THEAT" or Type == "HEATFS" or Type == "THEATFS" then
+		if Type == "HEAT" or Type == "THEAT" or Type == "HEATFS" or Type == "THEATFS" then
 
 			DamageModifier = Material.HEATMul
 
 		end
 
-		-- Breach probability
-		local breachProb = math.Clamp((caliber / armor / effectiveness - 1.3) / (7 - 1.3), 0, 1)
+		-- Breach probability, chance of a shell to shoot clean through without doing much structural damage ignoring richochet and LOS armor.
+		local breachProb = math.Clamp( (caliber * 10 / armor / effectiveness - 1.3) / 5.7 , 0, 1) -- If the caliber in mm is at least 1.3x the effective armor there is a chance to overmatch. At 7x the effective armor, 100% chance to overmatch.
 
 		-- Penetration probability
-		local penProb = (math.Clamp(1 / (1 + math.exp(-43.9445 * ( maxPenetration / losArmor / effectiveness - 1))), 0.0015, 0.9985) - 0.0015) / 0.997;
+		--The larger the number on the inside, the lower the penetration probability
+		--Penetration/Armor ratios below 1 lead to ludicrously large numbers, making penetration nearly impossible.
+		--Ratios of 1-2 lead to extremely small numbers around 1, causing penetration chances of ~40%-99%
+		--Ratios larger than 2 lead to ludicrously small numbers, making penetration almost guarenteed.
+		local penProb = (math.Clamp(1 / (1 + math.exp(-43.9445 * (maxPenetration / losArmor / effectiveness - 1))), 0.0015, 0.9985) - 0.0015) / 0.997
 
 		if breachProb > math.random() and maxPenetration > armor then			-- Breach chance roll
 
-			HitRes.Damage	= FrArea / resiliance * DamageModifier * damageMult						-- Inflicted Damage
+			HitRes.Damage	= FrArea * resiliance * DamageModifier * damageMult * ductilitymult						-- Inflicted Damage
 			HitRes.Overkill = maxPenetration - armor						-- Remaining penetration
 			HitRes.Loss	= armor / maxPenetration						-- Energy loss in percents
 
@@ -64,7 +67,7 @@ if SERVER then
 
 			local Penetration = math.min( maxPenetration, losArmor * effectiveness )
 
-			HitRes.Damage	= (( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea * DamageModifier * damageMult ) / resiliance
+			HitRes.Damage	= ( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea * DamageModifier * damageMult * resiliance * ductilitymult
 			HitRes.Overkill = (maxPenetration - Penetration)
 			HitRes.Loss	= Penetration / maxPenetration
 
@@ -75,7 +78,7 @@ if SERVER then
 		-- Projectile did not breach nor penetrate armor
 		local Penetration = math.min( maxPenetration , losArmor * effectiveness)
 
-		HitRes.Damage	= (( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea * DamageModifier * damageMult ) / resiliance
+		HitRes.Damage	= ( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea * DamageModifier * damageMult * resiliance * ductilitymult
 		HitRes.Overkill = 0
 		HitRes.Loss	= 1
 

--- a/lua/acf/shared/armor/cast.lua
+++ b/lua/acf/shared/armor/cast.lua
@@ -4,14 +4,17 @@ local Material		= {}
 Material.id			= "CHA"
 Material.name		= "Cast homogeneous Armor"
 Material.sname		= "CHA"
-Material.desc		= "A material that depiste of being heavier than RHA, provides more resiliance agaisnt the damage than its rolled version. Highly vulnerable to spalling."
+Material.desc		= "Despite of being heavier than RHA, Cast steel material provides more resiliance against damage than its rolled counterpart. Highly vulnerable to spalling."
 Material.year		= 1930
 
 Material.massMod		= 1.25
 Material.curve		= 1
 
+--All effectiveness values multiply the Line of Sight armor values of armor.
+--All Resiliance values are damage multipliers. Higher = more damage. Lower = less damage.
+
 Material.effectiveness  = 0.98
-Material.resiliance	= 2.25
+Material.resiliance	= 0.4
 
 Material.spallarmor	= 1
 Material.spallresist	= 0.5
@@ -29,19 +32,26 @@ if SERVER then
 		local effectiveness = Material.effectiveness
 		local resiliance	= Material.resiliance
 
+		local ductilityvalue = (Entity.ACF.Ductility or 0) * 1.25 --The ductility value of the armor. Outputs 1 to -1 depending on max ductility
+		local ductilitymult    = 2 / (2 - ductilityvalue * 1.5) -- Direct damage multiplier based on ductility.
+
 		armor	= armor ^ curve
 		losArmor	= losArmor ^ curve
 
-		-- Breach probability
-		local breachProb = math.Clamp((caliber / armor / effectiveness - 1.3) / (7 - 1.3), 0, 1)
+		-- Breach probability, chance of a shell to shoot clean through without doing much structural damage ignoring richochet and LOS armor.
+		local breachProb = math.Clamp( (caliber * 10 / armor / effectiveness - 1.3) / 5.7 , 0, 1) -- If the caliber in mm is at least 1.3x the effective armor there is a chance to overmatch. At 7x the effective armor, 100% chance to overmatch.
 
 		-- Penetration probability
-		local penProb = (math.Clamp(1 / (1 + math.exp(-43.9445 * (maxPenetration / losArmor / effectiveness - 1))), 0.0015, 0.9985) - 0.0015) / 0.997;
+		--The larger the number on the inside, the lower the penetration probability
+		--Penetration/Armor ratios below 1 lead to ludicrously large numbers, making penetration nearly impossible.
+		--Ratios of 1-2 lead to extremely small numbers around 1, causing penetration chances of ~40%-99%
+		--Ratios larger than 2 lead to ludicrously small numbers, making penetration almost guarenteed.
+		local penProb = (math.Clamp(1 / (1 + math.exp(-43.9445 * (maxPenetration / losArmor / effectiveness - 1))), 0.0015, 0.9985) - 0.0015) / 0.997
 
 		-- Breach chance roll
 		if breachProb > math.random() and maxPenetration > armor then
 
-			HitRes.Damage	= FrArea / resiliance * damageMult		-- Inflicted Damage
+			HitRes.Damage	= FrArea * resiliance * damageMult		-- Inflicted Damage
 			HitRes.Overkill = maxPenetration - armor						-- Remaining penetration
 			HitRes.Loss	= armor / maxPenetration						-- Energy loss in percents
 
@@ -52,7 +62,7 @@ if SERVER then
 
 			local Penetration = math.min( maxPenetration, losArmor * effectiveness )
 
-			HitRes.Damage	= (( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea / resiliance * damageMult ) / resiliance
+			HitRes.Damage	= ( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea * resiliance * damageMult * ductilitymult
 			HitRes.Overkill = ( maxPenetration - Penetration )
 			HitRes.Loss	= Penetration / maxPenetration
 
@@ -63,7 +73,7 @@ if SERVER then
 		-- Projectile did not breach nor penetrate armor
 		local Penetration = math.min( maxPenetration , losArmor * effectiveness )
 
-		HitRes.Damage	= (( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea / resiliance * damageMult ) / resiliance
+		HitRes.Damage	= ( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea * resiliance * damageMult * ductilitymult
 		HitRes.Overkill = 0
 		HitRes.Loss	= 1
 

--- a/lua/acf/shared/armor/ceramic.lua
+++ b/lua/acf/shared/armor/ceramic.lua
@@ -4,14 +4,17 @@ local Material		= {}
 Material.id			= "Cer"
 Material.name		= "Ceramic"
 Material.sname		= "Ceramic"
-Material.desc		= "The ceramic is mostly used to stop shells and penetrations in general, but its too fragil and tends to break easily."
+Material.desc		= "Ceramic is usually used as a material to ensure shells do not penetrate due to its high penetration resistance. Due to its frailty it is usually only used as a backing and is not meant to take the brunt of damage. Do not let it get penetrated or it will shatter."
 Material.year		= 1955
 
 Material.massMod		= 0.8
 Material.curve		= 0.95
 
+--All effectiveness values multiply the Line of Sight armor values of armor.
+--All Resiliance values are damage multipliers. Higher = more damage. Lower = less damage.
+
 Material.effectiveness  = 2.4
-Material.resiliance	= 0.01
+Material.resiliance	= 100
 
 Material.spallarmor	= 1
 Material.spallresist	= 1
@@ -21,7 +24,7 @@ Material.ArmorMul	= 1.8
 Material.NormMult	= 1.5
 
 if SERVER then
-	function Material.ArmorResolution( _, armor, losArmor, losArmorHealth, maxPenetration, FrArea, caliber, damageMult, Type)
+	function Material.ArmorResolution( Entity, armor, losArmor, losArmorHealth, maxPenetration, FrArea, _, damageMult, Type)
 
 		local HitRes = {}
 
@@ -29,38 +32,38 @@ if SERVER then
 		local effectiveness = Material.effectiveness
 		local resiliance	= Material.resiliance
 
+		local ductilityvalue = (Entity.ACF.Ductility or 0) * 1.25 --The ductility value of the armor. Outputs 1 to -1 depending on max ductility
+		local ductilitymult    = 2 / (2 - ductilityvalue * 1.5) -- Direct damage multiplier based on ductility.
+
 		armor = armor ^ curve
 		losArmor = losArmor ^ curve
 
-		local slopeDmg = ( losArmor / armor ) --Angled ceramic takes more damage. Fully angled ceramic takes up to 7x the damage
+		local dmul = ( losArmor / armor ) --Angled ceramic takes more damage. Fully angled ceramic takes up to 7x the damage
 
 		if Type == "HE" or Type == "HESH" then
-			slopeDmg = slopeDmg * 5
+			dmul = dmul * 15
 		end
 
-		local dmul = slopeDmg
-
-		-- Breach probability
-		local breachProb = math.Clamp((caliber / armor / effectiveness - 1.3) / (7 - 1.3), 0, 1)
+		--Removed Breaches from Ceramic. This was hard to balance, complicated calculations, and shouldn't really happen.
 
 		-- Penetration probability
+		--The larger the number on the inside, the lower the penetration probability
+		--Penetration/Armor ratios below 1 lead to ludicrously large numbers, making penetration nearly impossible.
+		--Ratios of 1-2 lead to extremely small numbers around 1, causing penetration chances of ~40%-99%
+		--Ratios larger than 2 lead to ludicrously small numbers, making penetration almost guarenteed.
 		local penProb = (math.Clamp(1 / (1 + math.exp(-43.9445 * (maxPenetration / losArmor / effectiveness - 1))), 0.0015, 0.9985) - 0.0015) / 0.997;
 
-		-- Breach chance roll
-		if breachProb > math.random() and maxPenetration > armor then
-
-			HitRes.Damage	= FrArea / resiliance * damageMult * dmul	-- Inflicted Damage
-			HitRes.Overkill = maxPenetration - armor												-- Remaining penetration
-			HitRes.Loss	= armor / maxPenetration												-- Energy loss in percents
-
-			return HitRes
-
 		-- Penetration chance roll
-		elseif penProb > math.random() then
+		if penProb > math.random() then
 
 			local Penetration = math.min( maxPenetration, losArmor * effectiveness )
 
-			HitRes.Damage	= ( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea / resiliance * damageMult * dmul
+			if maxPenetration > losArmor * effectiveness then
+				dmul = dmul * 20 --Damage multiplier for ceramic when it gets penned. Is this enough shatter?
+				Entity:EmitSound(Sound("physics/concrete/concrete_break2.wav"), 100, 100, 1, CHAN_WEAPON ) --I want to implement some sort of shatter sound. Would better be done through impact sounds.
+			end
+
+			HitRes.Damage	= ( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea * resiliance * damageMult * dmul * ductilitymult
 			HitRes.Overkill = ( maxPenetration - Penetration )
 			HitRes.Loss	= Penetration / maxPenetration
 
@@ -71,7 +74,7 @@ if SERVER then
 		-- Projectile did not breach nor penetrate armor
 		local Penetration = math.min( maxPenetration , losArmor * effectiveness )
 
-		HitRes.Damage	= ( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea / resiliance * damageMult * dmul
+		HitRes.Damage	= ( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea * resiliance * damageMult * dmul * ductilitymult
 		HitRes.Overkill = 0
 		HitRes.Loss	= 1
 

--- a/lua/acf/shared/armor/era.lua
+++ b/lua/acf/shared/armor/era.lua
@@ -4,11 +4,14 @@ local Material		= {}
 Material.id			= "ERA"
 Material.name		= "Explosive Reactive Armor"
 Material.sname		= "ERA"
-Material.desc		= "An explosive layered between 2 plates, when a shell penetrates it, the plate triggers its detonation, damaging or even destroying the incoming shell and saving the target, however, this material is as 2 times heavier than RHA and unlike other materials, this IS an explosive, so it will damage nearby props to the detonation. Explosive rounds can make life short for this material."
+Material.desc		= "An explosive composite sandwiched between 2 plates. When penetrated the plate detonates damaging or even destroying the incoming shell degrading its performance. This material is heavy compared to RHA and unlike other materials, will damage anything near the detonation. Explosive rounds can make short work of this material."
 Material.year		= 1955
 
 Material.massMod		= 2
 Material.curve		= 0.95
+
+--All effectiveness values multiply the Line of Sight armor values of armor.
+--All Resiliance values are damage multipliers. Higher = more damage. Lower = less damage.
 
 Material.effectiveness	= 2.5	--5 --Data before to angle factor. Needs proper testing
 Material.HEATeffectiveness  = 8	--20
@@ -148,7 +151,7 @@ if SERVER then
 			-- Breach chance roll
 			if breachProb > math.random() and maxPenetration > armor then
 
-				HitRes.Damage	= FrArea / resiliance * damageMult		-- Inflicted Damage
+				HitRes.Damage	= FrArea * resiliance * damageMult		-- Inflicted Damage
 				HitRes.Overkill = maxPenetration - armor					-- Remaining penetration
 				HitRes.Loss	= armor / maxPenetration					-- Energy loss in percents
 
@@ -159,7 +162,7 @@ if SERVER then
 
 				local Penetration = math.min( maxPenetration, losArmor * effectiveness)
 
-				HitRes.Damage	= ( ( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea / resiliance * damageMult )
+				HitRes.Damage	= ( ( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea * resiliance * damageMult )
 				HitRes.Overkill = ( maxPenetration - Penetration )
 				HitRes.Loss	= Penetration / maxPenetration
 
@@ -170,7 +173,7 @@ if SERVER then
 			-- Projectile did not breach nor penetrate armor
 			local Penetration = math.min( maxPenetration , losArmor * effectiveness )
 
-			HitRes.Damage	= (( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea / resiliance * damageMult ) / resiliance
+			HitRes.Damage	= ( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea * resiliance * damageMult
 			HitRes.Overkill = 0
 			HitRes.Loss	= 1
 

--- a/lua/acf/shared/armor/rha.lua
+++ b/lua/acf/shared/armor/rha.lua
@@ -4,11 +4,14 @@ local Material		= {}
 Material.id			= "RHA"
 Material.name		= "Rolled homogeneous Armor"
 Material.sname		= "RHA"
-Material.desc		= "Material which has no special traits. Your standart ACF armor."
+Material.desc		= "Simple, generic, but trusty steel. The standard armor everything else is compared to."
 Material.year		= 1900 -- Dont blame about this, ik that RHA has existed before this year but it would be cool to see: when?
 
 Material.massMod		= 1
-Material.curve		= 1
+Material.curve		= 0.99 --Slight and almost unnoticable penalty to high thickness armor
+
+--All effectiveness values multiply the Line of Sight armor values of armor.
+--All Resiliance values are damage multipliers. Higher = more damage. Lower = less damage.
 
 Material.effectiveness  = 1
 Material.resiliance	= 1
@@ -29,19 +32,32 @@ if SERVER then
 		local effectiveness = Material.effectiveness
 		local resiliance	= Material.resiliance
 
+		local ductilityvalue = (Entity.ACF.Ductility or 0) * 1.25 --The ductility value of the armor. Outputs 1 to -1 depending on max ductility
+		local ductilitymult    = 2 / (2 - ductilityvalue * 1.5) -- Direct damage multiplier based on ductility.
+
+
+
+		--(Entity.ACF.Ductility or 0)*2.5
+
+		--2.5 = (100)/40. Multiplies the decimal ductility. Will make damage multiplier 2 or 1/2 at max ductility
+
 		armor	= armor ^ curve
 		losArmor	= losArmor ^ curve
 
-		-- Breach probability
-		local breachProb = math.Clamp((caliber / armor / effectiveness - 1.3) / (7 - 1.3), 0, 1)
+		-- Breach probability, chance of a shell to shoot clean through without doing much structural damage ignoring richochet and LOS armor.
+		local breachProb = math.Clamp( (caliber * 10 / armor / effectiveness - 1.3) / 5.7 , 0, 1) -- If the caliber in mm is at least 1.3x the effective armor there is a chance to overmatch. At 7x the effective armor, 100% chance to overmatch.
 
 		-- Penetration probability
+		--The larger the number on the inside, the lower the penetration probability
+		--Penetration/Armor ratios below 1 lead to ludicrously large numbers, making penetration nearly impossible.
+		--Ratios of 1-2 lead to extremely small numbers around 1, causing penetration chances of ~40%-99%
+		--Ratios larger than 2 lead to ludicrously small numbers, making penetration almost guarenteed.
 		local penProb = (math.Clamp(1 / (1 + math.exp(-43.9445 * (maxPenetration / losArmor / effectiveness - 1))), 0.0015, 0.9985) - 0.0015) / 0.997;
 
 		-- Breach chance roll
 		if breachProb > math.random() and maxPenetration > armor then
 
-			HitRes.Damage	= FrArea / resiliance * damageMult		-- Inflicted Damage
+			HitRes.Damage	= FrArea * resiliance * damageMult * ductilitymult		-- Inflicted Damage
 			HitRes.Overkill = maxPenetration - armor					-- Remaining penetration
 			HitRes.Loss	= armor / maxPenetration					-- Energy loss in percents
 
@@ -52,7 +68,7 @@ if SERVER then
 
 			local Penetration = math.min( maxPenetration, losArmor * effectiveness)
 
-			HitRes.Damage	= ( ( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea / resiliance * damageMult )
+			HitRes.Damage	= ( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea * resiliance * damageMult * ductilitymult
 			HitRes.Overkill = ( maxPenetration - Penetration )
 			HitRes.Loss	= Penetration / maxPenetration
 
@@ -63,7 +79,7 @@ if SERVER then
 		-- Projectile did not breach nor penetrate armor
 		local Penetration = math.min( maxPenetration , losArmor * effectiveness )
 
-		HitRes.Damage	= (( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea / resiliance * damageMult ) / resiliance
+		HitRes.Damage	= ( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea * resiliance * damageMult * ductilitymult
 		HitRes.Overkill = 0
 		HitRes.Loss	= 1
 

--- a/lua/acf/shared/armor/rubber.lua
+++ b/lua/acf/shared/armor/rubber.lua
@@ -4,26 +4,33 @@ local Material		= {}
 Material.id			= "Rub"
 Material.name		= "Rubber"
 Material.sname		= "Rubber"
-Material.desc		= "Another Material, that while its totally useless agaisnt kinetic rounds, excels agaisnt shaped charges like HEAT"
+Material.desc		= "Another material that while useless against kinetic rounds, excels at stopping shaped charges and spall"
 Material.year		= 1955
 
 Material.massMod		= 0.2
 Material.curve		= 0.95
 
-Material.specialeffect  = 30
+Material.specialeffect  = 30 --Caliber to divide HEAT and spall caliber by when rubber catches the shells taking more of the energy. A caliber above this number results in a damage multiplier. ex 60mm/30 -> 2x
 
-Material.effectiveness  = 0.02
-Material.HEATeffectiveness = 3
-Material.resiliance	= 0.25
-Material.HEATresiliance = 0.3
-Material.HEresiliance	= 0.3
-Material.Catchresiliance = 0.25
+--All effectiveness values multiply the Line of Sight armor values of armor.
+--All Resiliance values are damage multipliers. Higher = more damage. Lower = less damage.
 
-Material.spallarmor	= 2
-Material.spallresist	= 3.5
+Material.effectiveness  = 0.05 --Kinetic effectiveness. What sociopath builds a tank out of rubber?
+Material.resiliance	= 2.5 --Resiliance against penetrating kinetic shells
+Material.Catchresiliance = 2 --Resiliance Multiplier used for kinetic shells when they fail to penetrate the armor and are "caught"
 
-Material.spallmult	= 0.01
-Material.ArmorMul	= 0.01
+
+Material.HEATeffectiveness = 4
+Material.HEATresiliance = 0.15
+
+Material.HEresiliance	= 6
+
+
+Material.spallarmor	= 1
+Material.spallresiliance = 2
+
+Material.spallmult	= 0.01 --While spall can pierce rubber, Rubber itself should not really spall.
+Material.ArmorMul	= 0.05
 Material.NormMult	= 0.05
 
 Material.Stopshock	= true
@@ -37,36 +44,45 @@ if SERVER then
 		local effectiveness = Material.effectiveness
 		local resiliance	= Material.resiliance
 
+		local ductilityvalue = (Entity.ACF.Ductility or 0) * 1.25 --The ductility value of the armor. Outputs 1 to -1 depending on max ductility
+		local ductilitymult    = 2 / (2 - ductilityvalue * 1.5) -- Direct damage multiplier based on ductility.
+
 		armor	= armor ^ curve
 		losArmor	= losArmor ^ curve
+
 
 		--=========================================================================================================\
 		--------------------------------------------------------- For HEAT shells & Spall -------------------------->
 		--=========================================================================================================/
-		if Type == "HEAT" or Type == "THEAT" or Type == "HEATFS" or Type == "THEATFS" or Type == "Spall" then
+		if Type == "HEAT" or Type == "THEAT" or Type == "HEATFS" or Type == "THEATFS" or Type == "Spall" then --Gotta love shelltype bloat. P L E A S E  Stop appeasing the bloaters.
 
-			local specialeffect		= Material.specialeffect
 			local specialeffectiveness  = Material.HEATeffectiveness
 			local specialresiliance	= Material.HEATresiliance
 
-			local spallresist = Material.spallresist
 
-			if Type == "Spall" then
-				specialeffectiveness = Material.effectiveness * spallresist
+			if Type == "Spall" then --Overrides effectiveness values if deflecting spall
+				specialeffectiveness = Material.spallarmor
+				specialresiliance = Material.spallresiliance
 			end
 
-			local DmgResist = 0.01 + math.min(caliber * 10 / specialeffect, 5) * 6
+			local DmgResist = 0.01 + math.min(caliber * 10 / Material.specialeffect, 5) * 10 --Caliber in mm / specialeffect. Makes HEAT shells with a larger jet shred rubber more.
 
-			-- Breach probability
-			local breachProb = math.Clamp((caliber / armor / specialeffectiveness - 1.3) / (7 - 1.3), 0, 1)
+			-- Breach probability, chance of a shell to shoot clean through without doing much structural damage ignoring richochet and LOS armor.
+			local breachProb = math.Clamp( (caliber * 10 / armor / specialeffectiveness - 1.3) / 5.7 , 0, 1) -- If the caliber in mm is at least 1.3x the effective armor there is a chance to overmatch. At 7x the effective armor, 100% chance to overmatch.
 
 			-- Penetration probability
+			--The larger the number on the inside, the lower the penetration probability
+			--Penetration/Armor ratios below 1 lead to ludicrously large numbers, making penetration nearly impossible.
+			--Ratios of 1-2 lead to extremely small numbers around 1, causing penetration chances of ~40%-99%
+			--Ratios larger than 2 lead to ludicrously small numbers, making penetration almost guarenteed.
 			local penProb = (math.Clamp(1 / (1 + math.exp(-43.9445 * ( maxPenetration / losArmor / specialeffectiveness - 1 ))), 0.0015, 0.9985) - 0.0015) / 0.997;
+
+
 
 			-- Breach chance roll
 			if breachProb > math.random() and maxPenetration > armor then
 
-				HitRes.Damage	= FrArea / specialresiliance * damageMult		-- Inflicted Damage
+				HitRes.Damage	= FrArea * specialresiliance * damageMult * ductilitymult		-- Inflicted Damage
 				HitRes.Overkill = maxPenetration - armor											-- Remaining penetration
 				HitRes.Loss	= armor / maxPenetration											-- Energy loss in percents
 
@@ -77,7 +93,7 @@ if SERVER then
 
 				local Penetration = math.min( maxPenetration, losArmor * specialeffectiveness )
 
-				HitRes.Damage = (Penetration / losArmorHealth / specialeffectiveness) ^ 2 * FrArea / specialresiliance * DmgResist * damageMult
+				HitRes.Damage = (Penetration / losArmorHealth / specialeffectiveness) ^ 2 * FrArea * specialresiliance * DmgResist * damageMult * ductilitymult
 				HitRes.Overkill = (maxPenetration - Penetration)
 				HitRes.Loss	= Penetration / maxPenetration
 
@@ -88,7 +104,7 @@ if SERVER then
 			-- Projectile did not breach nor penetrate armor
 			local Penetration = math.min( maxPenetration , losArmor * specialeffectiveness )
 
-			HitRes.Damage	= ( Penetration / losArmor / specialeffectiveness ) ^ 2 * FrArea / specialresiliance * DmgResist * damageMult
+			HitRes.Damage	= ( Penetration / losArmor / specialeffectiveness ) ^ 2 * FrArea * specialresiliance * DmgResist * damageMult * ductilitymult
 			HitRes.Overkill = 0
 			HitRes.Loss	= 1
 
@@ -97,22 +113,23 @@ if SERVER then
 		--------------------------------------------------------- For HE shells -------------------------->
 		--===============================================================================================/
 		elseif Type == "HE" then
-			--print("spalling2!!!")
-			--print(Type)
 
-			local specialeffectiveness = Material.HEATeffectiveness
 			local HEresiliance = Material.HEresiliance
 
-			-- Breach probability
-			local breachProb = math.Clamp((caliber / armor / HEresiliance - 1.3) / (7 - 1.3), 0, 1)
+			-- Breach probability, chance of a shell to shoot clean through without doing much structural damage ignoring richochet and LOS armor.
+			local breachProb = math.Clamp( (caliber * 10 / armor / effectiveness - 1.3) / 5.7 , 0, 1) -- If the caliber in mm is at least 1.3x the effective armor there is a chance to overmatch. At 7x the effective armor, 100% chance to overmatch.
 
 			-- Penetration probability
-			local penProb = (math.Clamp(1 / (1 + math.exp(-43.9445 * (maxPenetration / losArmor / specialeffectiveness - 1))), 0.0015, 0.9985) - 0.0015) / 0.997
+			--The larger the number on the inside, the lower the penetration probability
+			--Penetration/Armor ratios below 1 lead to ludicrously large numbers, making penetration nearly impossible.
+			--Ratios of 1-2 lead to extremely small numbers around 1, causing penetration chances of ~40%-99%
+			--Ratios larger than 2 lead to ludicrously small numbers, making penetration almost guarenteed.
+			local penProb = (math.Clamp(1 / (1 + math.exp(-43.9445 * ( maxPenetration / losArmor / effectiveness - 1 ))), 0.0015, 0.9985) - 0.0015) / 0.997;
 
 			-- Breach chance roll
 			if breachProb > math.random() and maxPenetration > armor then
 
-				HitRes.Damage	= FrArea / HEresiliance  * damageMult	-- Inflicted Damage
+				HitRes.Damage	= FrArea * HEresiliance  * damageMult * ductilitymult	-- Inflicted Damage
 				HitRes.Overkill = maxPenetration - armor							-- Remaining penetration
 				HitRes.Loss	= armor / maxPenetration							-- Energy loss in percents
 
@@ -121,9 +138,9 @@ if SERVER then
 			-- Penetration chance roll
 			elseif penProb > math.random() then
 
-				local Penetration = math.min( maxPenetration, losArmor * specialeffectiveness )
+				local Penetration = math.min( maxPenetration, losArmor * effectiveness )
 
-				HitRes.Damage	= ( Penetration / losArmorHealth / specialeffectiveness ) ^ 2 * FrArea / HEresiliance * damageMult
+				HitRes.Damage	= ( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea * HEresiliance * damageMult * ductilitymult
 				HitRes.Overkill = (maxPenetration - Penetration)
 				HitRes.Loss	= Penetration / maxPenetration
 
@@ -132,9 +149,9 @@ if SERVER then
 			end
 
 			-- Projectile did not breach nor penetrate armor
-			local Penetration = math.min( maxPenetration , losArmor * specialeffectiveness )
+			local Penetration = math.min( maxPenetration , losArmor * effectiveness )
 
-			HitRes.Damage	= ( Penetration / losArmorHealth / specialeffectiveness ) ^ 2 * FrArea / HEresiliance * damageMult
+			HitRes.Damage	= ( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea * HEresiliance * damageMult * ductilitymult
 			HitRes.Overkill = 0
 			HitRes.Loss	= 1
 
@@ -145,18 +162,21 @@ if SERVER then
 		--===============================================================================================/
 		else
 
-			local Catchresiliance = Material.Catchresiliance
+			-- Breach probability, chance of a shell to shoot clean through without doing much structural damage ignoring richochet and LOS armor.
+			local breachProb = math.Clamp( (caliber * 10 / armor / effectiveness - 1.3) / 5.7 , 0, 1) -- If the caliber in mm is at least 1.3x the effective armor there is a chance to overmatch. At 7x the effective armor, 100% chance to overmatch.
 
-			-- Breach probability
-			local breachProb = math.Clamp((caliber / armor / effectiveness - 1.3) / (7 - 1.3), 0, 1)
 
 			-- Penetration probability
-			local penProb = (math.Clamp(1 / (1 + math.exp(-43.9445 * (maxPenetration / losArmor / effectiveness - 1))), 0.0015, 0.9985) - 0.0015) / 0.997;
+			--The larger the number on the inside, the lower the penetration probability
+			--Penetration/Armor ratios below 1 lead to ludicrously large numbers, making penetration nearly impossible.
+			--Ratios of 1-2 lead to extremely small numbers around 1, causing penetration chances of ~40%-99%
+			--Ratios larger than 2 lead to ludicrously small numbers, making penetration almost guarenteed.
+			local penProb = (math.Clamp(1 / (1 + math.exp(-43.9445 * ( maxPenetration / losArmor / effectiveness - 1 ))), 0.0015, 0.9985) - 0.0015) / 0.997;
 
 			-- Breach chance roll
 			if breachProb > math.random() and maxPenetration > armor then
 
-				HitRes.Damage	= FrArea / resiliance * damageMult						-- Inflicted Damage
+				HitRes.Damage	= FrArea * resiliance * damageMult * ductilitymult						-- Inflicted Damage
 				HitRes.Overkill = maxPenetration - armor						-- Remaining penetration
 				HitRes.Loss	= armor / maxPenetration						-- Energy loss in percents
 
@@ -167,11 +187,10 @@ if SERVER then
 
 				local Penetration = math.min( maxPenetration, losArmor * effectiveness )
 
-				HitRes.Damage	= ( Penetration / losArmorHealth * effectiveness ) ^ 2 * FrArea / resiliance * damageMult
+				HitRes.Damage	= ( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea * resiliance * damageMult * ductilitymult
 				HitRes.Overkill = (maxPenetration - Penetration)
 				HitRes.Loss	= Penetration / maxPenetration
 
-				--print('Damage applied: ' .. HitRes.Damage)
 				return HitRes
 
 			end
@@ -179,7 +198,7 @@ if SERVER then
 			-- Projectile did not breach nor penetrate armor
 			local Penetration = math.min( maxPenetration , losArmor * effectiveness )
 
-			HitRes.Damage	= ( Penetration / losArmorHealth * effectiveness ) ^ 2 * FrArea / Catchresiliance * damageMult
+			HitRes.Damage	= ( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea * Material.Catchresiliance * damageMult * ductilitymult
 			HitRes.Overkill = 0
 			HitRes.Loss	= 1
 

--- a/lua/acf/shared/armor/textolite.lua
+++ b/lua/acf/shared/armor/textolite.lua
@@ -4,27 +4,28 @@ local Material		= {}
 Material.id			= "Texto"
 Material.name		= "Textolite"
 Material.sname		= "Textolite"
-Material.desc		= "As known as fiberglass, this chemical material provides a fairly protection agaisnt both kinetic and chemical rounds, including agaisnt explosive rounds, although its mediocre at all."
+Material.desc		= "Fiberglass based material, this material provides decent protection agaisnt both chemical especially and kinetic rounds, while taking reduced damage from explosions."
 Material.year		= 1955
 
 Material.massMod		= 0.35
 Material.curve		= 0.94
 
+--All effectiveness values multiply the Line of Sight armor values of armor.
+--All Resiliance values are damage multipliers. Higher = more damage. Lower = less damage.
+
 Material.effectiveness	= 0.5
 Material.HEATeffectiveness  = 1.2
 Material.HEeffectiveness	= 0.9
-Material.resiliance		= 0.005
-Material.HEATresiliance	= 2
-Material.HEresiliance	= 1.3
+Material.resiliance		= 50
+Material.HEATresiliance	= 0.5
+Material.HEresiliance	= 0.75
 
 Material.spallarmor	= 1
-Material.spallresist	= 1.5
+Material.spallresist	= 0.65
 
 Material.spallmult	= 1.3
 Material.ArmorMul	= 0.23
 Material.NormMult	= 0.5
-
-Material.Stopshock	= true
 
 if SERVER then
 	function Material.ArmorResolution( Entity, armor, losArmor, losArmorHealth, maxPenetration, FrArea, caliber, _, Type)
@@ -35,6 +36,8 @@ if SERVER then
 		local effectiveness = Material.effectiveness
 		local resiliance	= Material.resiliance
 
+		local ductilityvalue = (Entity.ACF.Ductility or 0) * 1.25 --The ductility value of the armor. Outputs 1 to -1 depending on max ductility
+		local ductilitymult    = 2 / (2 - ductilityvalue * 1.5) -- Direct damage multiplier based on ductility.
 		armor	= armor ^ curve
 		losArmor	= losArmor ^ curve
 
@@ -43,15 +46,19 @@ if SERVER then
 			local HEATeffectiveness = Material.HEATeffectiveness
 			local HEATresiliance = Material.HEATresiliance
 
-			-- Breach probability
-			local breachProb = math.Clamp((caliber / Entity.ACF.Armour / HEATeffectiveness - 1.3) / (7 - 1.3), 0, 1)
+			-- Breach probability, chance of a shell to shoot clean through without doing much structural damage ignoring richochet and LOS armor.
+			local breachProb = math.Clamp( (caliber * 10 / armor / HEATeffectiveness - 1.3) / 5.7 , 0, 1) -- If the caliber in mm is at least 1.3x the effective armor there is a chance to overmatch. At 7x the effective armor, 100% chance to overmatch.
 
 			-- Penetration probability
+			--The larger the number on the inside, the lower the penetration probability
+			--Penetration/Armor ratios below 1 lead to ludicrously large numbers, making penetration nearly impossible.
+			--Ratios of 1-2 lead to extremely small numbers around 1, causing penetration chances of ~40%-99%
+			--Ratios larger than 2 lead to ludicrously small numbers, making penetration almost guarenteed.
 			local penProb = (math.Clamp(1 / (1 + math.exp(-43.9445 * (maxPenetration / losArmor / HEATeffectiveness - 1))), 0.0015, 0.9985) - 0.0015) / 0.997;
 
 			if breachProb > math.random() and maxPenetration > armor * HEATeffectiveness then			-- Breach chance roll
 
-				HitRes.Damage	= FrArea / HEATresiliance						-- Inflicted Damage
+				HitRes.Damage	= FrArea * HEATresiliance * ductilitymult						-- Inflicted Damage
 				HitRes.Overkill = maxPenetration - armor * HEATeffectiveness						-- Remaining penetration
 				HitRes.Loss	= armor * HEATeffectiveness / maxPenetration						-- Energy loss in percents
 
@@ -62,7 +69,7 @@ if SERVER then
 
 				local Penetration = math.min( maxPenetration, losArmor * HEATeffectiveness )
 
-				HitRes.Damage	= ( Penetration / losArmorHealth / HEATeffectiveness ) ^ 2 * FrArea / HEATresiliance
+				HitRes.Damage	= ( Penetration / losArmorHealth / HEATeffectiveness ) ^ 2 * FrArea * HEATresiliance * ductilitymult
 				HitRes.Overkill = (maxPenetration - Penetration)
 				HitRes.Loss	= Penetration / maxPenetration
 
@@ -73,7 +80,7 @@ if SERVER then
 			-- Projectile did not breach nor penetrate armor
 			local Penetration = math.min( maxPenetration , losArmor * HEATeffectiveness )
 
-			HitRes.Damage	= ( Penetration / losArmor / HEATeffectiveness ) ^ 2 * FrArea / HEATresiliance
+			HitRes.Damage	= ( Penetration / losArmor / HEATeffectiveness ) ^ 2 * FrArea * HEATresiliance * ductilitymult
 			HitRes.Overkill = 0
 			HitRes.Loss	= 1
 
@@ -84,16 +91,20 @@ if SERVER then
 			local HEeffectiveness = Material.HEeffectiveness
 			local HEresiliance = Material.HEresiliance
 
-			-- Breach probability
-			local breachProb = math.Clamp((caliber / Entity.ACF.Armour / HEeffectiveness - 1.3) / (7 - 1.3), 0, 1)
+			-- Breach probability, chance of a shell to shoot clean through without doing much structural damage ignoring richochet and LOS armor.
+			local breachProb = math.Clamp( (caliber * 10 / armor / HEeffectiveness - 1.3) / 5.7 , 0, 1) -- If the caliber in mm is at least 1.3x the effective armor there is a chance to overmatch. At 7x the effective armor, 100% chance to overmatch.
 
 			-- Penetration probability
+			--The larger the number on the inside, the lower the penetration probability
+			--Penetration/Armor ratios below 1 lead to ludicrously large numbers, making penetration nearly impossible.
+			--Ratios of 1-2 lead to extremely small numbers around 1, causing penetration chances of ~40%-99%
+			--Ratios larger than 2 lead to ludicrously small numbers, making penetration almost guarenteed.
 			local penProb = (math.Clamp(1 / (1 + math.exp(-43.9445 * (maxPenetration / losArmor / HEeffectiveness - 1))), 0.0015, 0.9985) - 0.0015) / 0.997;
 
 			-- Breach chance roll
 			if breachProb > math.random() and maxPenetration > armor then
 
-				HitRes.Damage	= FrArea / HEresiliance						-- Inflicted Damage
+				HitRes.Damage	= FrArea * HEresiliance * ductilitymult						-- Inflicted Damage
 				HitRes.Overkill = maxPenetration - armor						-- Remaining penetration
 				HitRes.Loss	= armor / maxPenetration						-- Energy loss in percents
 
@@ -104,7 +115,7 @@ if SERVER then
 
 				local Penetration = math.min( maxPenetration, losArmor * HEeffectiveness )
 
-				HitRes.Damage	= ( Penetration / losArmorHealth / HEeffectiveness ) ^ 2 * FrArea / HEresiliance
+				HitRes.Damage	= ( Penetration / losArmorHealth / HEeffectiveness ) ^ 2 * FrArea * HEresiliance * ductilitymult
 				HitRes.Overkill = (maxPenetration - Penetration)
 				HitRes.Loss	= Penetration / maxPenetration
 
@@ -115,7 +126,7 @@ if SERVER then
 			-- Projectile did not breach nor penetrate armor
 			local Penetration = math.min( maxPenetration , losArmor * HEeffectiveness )
 
-			HitRes.Damage	= ( Penetration / losArmorHealth / HEeffectiveness ) ^ 2 * FrArea / HEresiliance
+			HitRes.Damage	= ( Penetration / losArmorHealth / HEeffectiveness ) ^ 2 * FrArea * HEresiliance * ductilitymult
 			HitRes.Overkill = 0
 			HitRes.Loss	= 1
 
@@ -123,43 +134,41 @@ if SERVER then
 
 		else
 
-			-- Breach probability
-			local breachProb = math.Clamp((caliber / Entity.ACF.Armour * effectiveness - 1.3) / (7 - 1.3), 0, 1)
+			-- Breach probability, chance of a shell to shoot clean through without doing much structural damage ignoring richochet and LOS armor.
+			local breachProb = math.Clamp( (caliber * 10 / armor / effectiveness - 1.3) / 5.7 , 0, 1) -- If the caliber in mm is at least 1.3x the effective armor there is a chance to overmatch. At 7x the effective armor, 100% chance to overmatch.
 
 			-- Penetration probability
+			--The larger the number on the inside, the lower the penetration probability
+			--Penetration/Armor ratios below 1 lead to ludicrously large numbers, making penetration nearly impossible.
+			--Ratios of 1-2 lead to extremely small numbers around 1, causing penetration chances of ~40%-99%
+			--Ratios larger than 2 lead to ludicrously small numbers, making penetration almost guarenteed.
 			local penProb = (math.Clamp(1 / (1 + math.exp(-43.9445 * (maxPenetration / losArmor / effectiveness - 1))), 0.0015, 0.9985) - 0.0015) / 0.997;
 
 			if breachProb > math.random() and maxPenetration > armor then			-- Breach chance roll
 
-	--		print("RubberBreach")
-				HitRes.Damage	= FrArea / resiliance							-- Inflicted Damage
+				HitRes.Damage	= FrArea * resiliance * ductilitymult							-- Inflicted Damage
 				HitRes.Overkill = maxPenetration - armor						-- Remaining penetration
 				HitRes.Loss	= armor / maxPenetration						-- Energy loss in percents
-	--			print("DmgBreach: " .. HitRes.Damage)
 
 				return HitRes
 
 			elseif penProb > math.random() then								-- Penetration chance roll
 
-	--		print("RubberBreach")
 				local Penetration = math.min( maxPenetration, losArmor * effectiveness )
-				HitRes.Damage	= ( Penetration / losArmorHealth * effectiveness) ^ 2 * FrArea / resiliance
+				HitRes.Damage	= ( Penetration / losArmorHealth / effectiveness) ^ 2 * FrArea * resiliance * ductilitymult
 				HitRes.Overkill = (maxPenetration - Penetration)
 				HitRes.Loss	= Penetration / maxPenetration
-	--		print("DmgPen: " .. HitRes.Damage)
 
 				return HitRes
 
 			end
 
-	--		print("NoBreach")
 			-- Projectile did not breach nor penetrate armor
 			local Penetration = math.min( maxPenetration , losArmor * effectiveness )
 
-			HitRes.Damage	= ( Penetration / losArmorHealth * effectiveness ) ^ 2 * FrArea / resiliance
+			HitRes.Damage	= ( Penetration / losArmorHealth / effectiveness ) ^ 2 * FrArea * resiliance * ductilitymult
 			HitRes.Overkill = 0
 			HitRes.Loss	= 1
-	--		print("DmgNoPen: " .. HitRes.Damage)
 			return HitRes
 
 		end

--- a/lua/acf/shared/rounds/roundapfsds.lua
+++ b/lua/acf/shared/rounds/roundapfsds.lua
@@ -37,7 +37,7 @@ function Round.convert( _, PlayerData )
 
 	Data.MinCalMult		= 0.2
 	Data.MaxCalMult		= 1.0
-	Data.PenModifier		= 0.8
+	Data.PenModifier		= 1.08 --for 120mm. 726 @ 1.1. 630 @1.3
 	Data.VelModifier		= 1.1
 	Data.Ricochet		= 80
 

--- a/lua/autorun/acf_globals.lua
+++ b/lua/autorun/acf_globals.lua
@@ -129,7 +129,7 @@ ACF.RefillSpeed         = 250					-- (ACF.RefillSpeed / RoundMass) / Distance
 ---------------------------------- Explosive config ----------------------------------
 
 ACF.HEDamageFactor    = 50
-ACF.BoomMult          = 1.5					-- How much more do ammocrates/fueltanks blow up, useful since crates detonate all at once now.
+ACF.BoomMult          = 3.5					-- How much more do ammocrates/fueltanks blow up, useful since crates detonate all at once now.
 
 ACF.HEPower           = 8000					-- HE Filler power per KG in KJ
 ACF.HEDensity         = 1.65					-- HE Filler density (That's TNT density)

--- a/lua/weapons/gmod_tool/stools/acfsound.lua
+++ b/lua/weapons/gmod_tool/stools/acfsound.lua
@@ -166,17 +166,13 @@ local function ReplaceSound( _ , Entity , data)
 			pitch = 100
 		end
 
-		-- Workaround to fix issue with StoreEntityModifier not loading on certain entities
-		-- For some reason, the naming "acf_replacesound" seems not to work with the "acf_rack" entities on dedicated servers. Changing the identifier for other not sharing some keywords fixed it.
 		local newdata = {sound, pitch, true}
 		support.SetSound(Entity, {Sound = sound, Pitch = pitch})
-		duplicator.StoreEntityModifier( Entity, "ACFCustomSounds", newdata ) -- The new test identifier. The old one doesnt work properly with some ents
 		duplicator.StoreEntityModifier( Entity, "acf_replacesound", newdata )
 	end
 end
 
-duplicator.RegisterEntityModifier( "ACFCustomSounds", ReplaceSound )
-duplicator.RegisterEntityModifier( "acf_replacesound", ReplaceSound ) -- Still calling the old identifier. We don't want old builds to lose their custom sounds if not edited later.
+duplicator.RegisterEntityModifier( "acf_replacesound", ReplaceSound )
 
 local function IsReallyValid(trace, ply)
 	if not trace.Entity:IsValid() then return false end
@@ -239,7 +235,6 @@ function TOOL:Reload( trace )
 	support.ResetSound(trace.Entity)
 
 	duplicator.ClearEntityModifier( trace.Entity, "acf_replacesound" )
-	duplicator.ClearEntityModifier( trace.Entity, "ACFCustomSounds" )
 
 	return true
 end

--- a/lua/weapons/gmod_tool/stools/acfsound.lua
+++ b/lua/weapons/gmod_tool/stools/acfsound.lua
@@ -359,4 +359,3 @@ if CLIENT then
 	end
 
 end
-


### PR DESCRIPTION
Noncritical
-Fixed several typos and reworded armor descriptions
-Changed resistances from divide to multiplier. Fixed several operation errors.

Balance related
-Rubber changed to 0.05 kinetic, 4x Heat, 1x Spall. Significantly reworked damage methods and cleaned up multipliers.
-Armor values unchanged. Added system where ceramic takes increased damage from penetrations and fixed error in damage calculation. Increased damage received overall.
-Reduced penetration of smoothbore cannons. This should reduce the gap between customs and realistic tanks somewhat by making extreme values of armor only obtained by ceramics not a requirement.
--Added new ductility multiplier to all armors except ERA. This means extremes of armor will take significantly less or significantly more damage and makes lower ductility less capable.