### PR TITLE
Crew seat legality improvements, add crew orientation penalties

### DIFF
--- a/lua/entities/ace_crewseat_driver/init.lua
+++ b/lua/entities/ace_crewseat_driver/init.lua
@@ -3,6 +3,9 @@ AddCSLuaFile("shared.lua")
 
 include("shared.lua")
 
+local acos, deg, remap, clamp = math.acos, math.deg, math.Remap, math.Clamp
+local round, ceil, random = math.Round, math.ceil, math.random
+
 function ENT:SpawnFunction( _, trace )
 
 	if not trace.Hit then return end
@@ -35,34 +38,37 @@ function ENT:Initialize()
 	self.ACF.MaxHealth = 1
 	self.Name = "Crew Seat"
 	self.Weight = 60
+	self.AnglePenalty = 0
+	self.LinkedEngine = nil
 
-	self.NextLegalCheck	= ACF.CurTime + math.random(ACF.Legal.Min, ACF.Legal.Max) -- give any spawning issues time to iron themselves out
+	self.NextLegalCheck	= ACF.CurTime + random(ACF.Legal.Min, ACF.Legal.Max) -- give any spawning issues time to iron themselves out
 	self.Legal = true
 	self.LegalIssues = ""
 
-	-- List of rare names
 	local rareNames = {"Mr.Marty", "RDC", "Cheezus", "KemGus", "Golem Man", "Arend", "Mac", "Firstgamerable", "kerbal cadet", "Psycho Dog", "Steve", "Ferv", "Twisted", "Red", "nrulz"}
 
-	-- Generate a random number between 1 and 10
-	local randomNum = math.random(1, 100)
+	local randomNum = random(1, 100)
 
 	if randomNum <= 2 then
-		-- Choose a rare name
-		self.Name  = rareNames[math.random(1, #rareNames)]
+		self.Name  = rareNames[random(1, #rareNames)]
 	else
-		-- Generate a random name
 		local randomPrefixes = {"John", "Bob", "Sam", "Joe", "Ben", "Alex", "Chris", "David", "Eric", "Frank", "Antonio", "Ivan"}
 		local randomSuffixes = {"Smith", "Johnson", "Dover", "Wang", "Kim", "Lee", "Brown", "Davis", "Evans", "Garcia", "", "Russel", "King"}
 
-		local randomPrefix = randomPrefixes[math.random(1, #randomPrefixes)]
-		local randomSuffix = randomSuffixes[math.random(1, #randomSuffixes)]
+		local randomPrefix = randomPrefixes[random(1, #randomPrefixes)]
+		local randomSuffix = randomSuffixes[random(1, #randomSuffixes)]
 
 		self.Name  = randomPrefix .. " " .. randomSuffix
 	end
 end
 
 
+local startPenalty = 45
+local maxPenalty = 90
+
 function ENT:Think()
+	local curSeatAngle = deg(acos(self:GetUp():Dot(Vector(0, 0, 1))))
+	self.AnglePenalty = clamp(remap(curSeatAngle, startPenalty, maxPenalty, 0, 1), 0, 1)
 
 	if self.ACF.Health <= self.ACF.MaxHealth * 0.97 then
 		ACF_HEKill( self, VectorRand() , 0)
@@ -71,9 +77,14 @@ function ENT:Think()
 
 	if ACF.CurTime > self.NextLegalCheck then
 
-		self.Legal, self.LegalIssues = ACF_CheckLegal(self, self.Model, math.Round(self.Weight, 2), nil, true, true)
+		self.Legal, self.LegalIssues = ACF_CheckLegal(self, self.Model, round(self.Weight, 2), nil, true, true)
 		self.NextLegalCheck = ACF.Legal.NextCheck(self.legal)
 
+	end
+
+	local eng = self.LinkedEngine
+	if not self.Legal and IsValid(eng) then
+		eng:Unlink(self)
 	end
 
 	self:UpdateOverlayText()
@@ -91,12 +102,12 @@ function ENT:OnRemove()
 end
 
 function ENT:UpdateOverlayText()
-	local hp = math.Round(self.ACF.Health / self.ACF.MaxHealth * 100)
+	local hp = round(self.ACF.Health / self.ACF.MaxHealth * 100)
 
 	local str = string.format("Health: %s%%\nName: %s", hp, self.Name)
 
 	if not self.Legal then
-		str = str .. "\n\nNot legal, disabled for " .. math.ceil(self.NextLegalCheck - ACF.CurTime) .. "s\nIssues: " .. self.LegalIssues
+		str = str .. "\n\nNot legal, disabled for " .. ceil(self.NextLegalCheck - ACF.CurTime) .. "s\nIssues: " .. self.LegalIssues
 	end
 
 	self:SetOverlayText(str)

--- a/lua/entities/ace_crewseat_gunner/init.lua
+++ b/lua/entities/ace_crewseat_gunner/init.lua
@@ -3,6 +3,9 @@ AddCSLuaFile("shared.lua")
 
 include("shared.lua")
 
+local acos, deg, remap, clamp = math.acos, math.deg, math.Remap, math.Clamp
+local round, ceil, random = math.Round, math.ceil, math.random
+
 function ENT:SpawnFunction( _, trace )
 
 	if not trace.Hit then return end
@@ -35,45 +38,53 @@ function ENT:Initialize()
 	self.ACF.MaxHealth = 1
 	self.Name = "Crew Seat"
 	self.Weight = 60
+	self.AnglePenalty = 0
+	self.LinkedGun = nil
 
-	self.NextLegalCheck	= ACF.CurTime + math.random(ACF.Legal.Min, ACF.Legal.Max) -- give any spawning issues time to iron themselves out
+	self.NextLegalCheck	= ACF.CurTime + random(ACF.Legal.Min, ACF.Legal.Max) -- give any spawning issues time to iron themselves out
 	self.Legal = true
 	self.LegalIssues = ""
 
-	-- List of rare names
 	local rareNames = {"Mr.Marty", "RDC", "Cheezus", "KemGus", "Golem Man", "Arend", "Mac", "Firstgamerable", "kerbal cadet", "Psycho Dog", "Steve", "Ferv", "Twisted", "Red", "nrulz"}
 
-	-- Generate a random number between 1 and 10
-	local randomNum = math.random(1, 100)
+	local randomNum = random(1, 100)
 
 	if randomNum <= 2 then
-		-- Choose a rare name
-		self.Name  = rareNames[math.random(1, #rareNames)]
+		self.Name  = rareNames[random(1, #rareNames)]
 	else
-		-- Generate a random name
 		local randomPrefixes = {"John", "Bob", "Sam", "Joe", "Ben", "Alex", "Chris", "David", "Eric", "Frank", "Antonio", "Ivan"}
 		local randomSuffixes = {"Smith", "Johnson", "Dover", "Wang", "Kim", "Lee", "Brown", "Davis", "Evans", "Garcia", "", "Russel", "King"}
 
-		local randomPrefix = randomPrefixes[math.random(1, #randomPrefixes)]
-		local randomSuffix = randomSuffixes[math.random(1, #randomSuffixes)]
+		local randomPrefix = randomPrefixes[random(1, #randomPrefixes)]
+		local randomSuffix = randomSuffixes[random(1, #randomSuffixes)]
 
 		self.Name  = randomPrefix .. " " .. randomSuffix
 	end
 end
 
 
+local startPenalty = 45
+local maxPenalty = 90
+
 function ENT:Think()
+	local curSeatAngle = deg(acos(self:GetUp():Dot(Vector(0, 0, 1))))
+	self.AnglePenalty = clamp(remap(curSeatAngle, startPenalty, maxPenalty, 0, 1), 0, 1)
 
 	if self.ACF.Health <= self.ACF.MaxHealth * 0.97 then
 		ACF_HEKill( self, VectorRand() , 0)
-		self:EmitSound("npc/combine_soldier/die" .. tostring(math.random(1, 3)) .. ".wav", 50)
+		self:EmitSound("npc/combine_soldier/die" .. tostring(random(1, 3)) .. ".wav", 50)
 	end
 
 	if ACF.CurTime > self.NextLegalCheck then
 
-		self.Legal, self.LegalIssues = ACF_CheckLegal(self, self.Model, math.Round(self.Weight, 2), nil, true, true)
+		self.Legal, self.LegalIssues = ACF_CheckLegal(self, self.Model, round(self.Weight, 2), nil, true, true)
 		self.NextLegalCheck = ACF.Legal.NextCheck(self.legal)
 
+	end
+
+	local gun = self.LinkedGun
+	if not self.Legal and IsValid(gun) then
+		gun:Unlink(self)
 	end
 
 	self:UpdateOverlayText()
@@ -91,12 +102,12 @@ function ENT:OnRemove()
 end
 
 function ENT:UpdateOverlayText()
-	local hp = math.Round(self.ACF.Health / self.ACF.MaxHealth * 100)
+	local hp = round(self.ACF.Health / self.ACF.MaxHealth * 100)
 
 	local str = string.format("Health: %s%%\nName: %s", hp, self.Name )
 
 	if not self.Legal then
-		str = str .. "\n\nNot legal, disabled for " .. math.ceil(self.NextLegalCheck - ACF.CurTime) .. "s\nIssues: " .. self.LegalIssues
+		str = str .. "\n\nNot legal, disabled for " .. ceil(self.NextLegalCheck - ACF.CurTime) .. "s\nIssues: " .. self.LegalIssues
 	end
 
 	self:SetOverlayText(str)

--- a/lua/entities/acf_engine/init.lua
+++ b/lua/entities/acf_engine/init.lua
@@ -755,6 +755,7 @@ function ENT:Link( Target )
 		table.insert( self.CrewLink, Target )
 		table.insert( Target.Master, self )
 
+		Target.LinkedEngine = self
 		self.HasDriver = 1
 		self:UpdateOverlayText()
 
@@ -813,6 +814,7 @@ function ENT:Unlink( Target )
 			table.remove(self.CrewLink,Key)
 			Success = true
 			self.HasDriver = 0
+			Target.LinkedEngine = nil
 			return true, "Unlink successful!"
 		end
 	end

--- a/lua/entities/acf_gun/init.lua
+++ b/lua/entities/acf_gun/init.lua
@@ -360,6 +360,7 @@ function ENT:Link( Target )
 		table.insert( Target.Master, self )
 
 		self.HasGunner = true
+		Target.LinkedGun = self
 
 		return true, "Link successful!"
 
@@ -470,6 +471,8 @@ function ENT:Unlink( Target )
 			elseif Target:GetClass() == "ace_crewseat_loader" then
 				self.LoaderCount = self.LoaderCount - 1
 			end
+
+			Target.LinkedGun = nil
 
 			table.remove(self.CrewLink,Key)
 			Success = true
@@ -622,14 +625,6 @@ end
 	end
 ]]
 
-function ENT:IllegalCrewSeatRemove(crewEntities)
-	for _, crewEnt in ipairs(crewEntities) do
-		if not crewEnt.Legal then
-			self:Unlink(crewEnt)
-		end
-	end
-end
-
 function ENT:Think()
 
 	--Legality check part
@@ -649,8 +644,6 @@ function ENT:Think()
 				self.LegalIssues = self.LegalIssues .. "\nSeat not legal: " .. issues
 			end
 		end
-
-		self:IllegalCrewSeatRemove(self.CrewLink)
 
 		self:UpdateOverlayText()
 
@@ -796,7 +789,7 @@ do
 		for _, crewEnt in ipairs(self.CrewLink) do
 			if crewEnt:GetClass() == "ace_crewseat_loader" and crewEnt.Legal then
 				local stamina = crewEnt.Stamina
-				if stamina > highestStamina then
+				if stamina >= highestStamina then
 					highestStamina = stamina
 					highestStaminaLoader = crewEnt
 				end
@@ -967,7 +960,7 @@ function ENT:LoadAmmo( AddTime, Reload )
 		-- Check if self.Class is in the invalidClasses table
 		if not ACE_table_contains(invalidClasses, self.Class) and self.maxrof then
 
-			if self.LoaderCount > 0 then -- if loaders are linked then
+			if self.LoaderCount > 0 and IsValid(curLoader) then -- if loaders are linked then
 
 				local CrewReload = curLoaderStamina / 100
 				local reloadTime = lowestReloadTime / CrewReload -- in seconds!!!!


### PR DESCRIPTION
- Crew seats will unlink themselves from linked components if they are deemed illegal
- Loaders will have a penalty based on their angle from the world up vector. No
    - No penalty for 0 to 45 degrees
    - Increases linearly between 45 and 90 degrees
    - At 90 degrees from vertical or higher, stamina does not regenerate at all
