### PR TITLE
Spall rework

### DIFF
--- a/lua/acf/server/sv_acfbase.lua
+++ b/lua/acf/server/sv_acfbase.lua
@@ -206,9 +206,9 @@ function ACF_CalcDamage( Entity , Energy , FrArea , Angle , Type) --y=-5/16x + b
 	local caliber = 20 * (FrArea ^ (1 / ACF.PenAreaMod) / 3.1416) ^ 0.5
 
 	--Nifty shell information debugging.
-	print("Type: "..Type)
-	print("Penetration: "..math.Round(maxPenetration,3).."mm")
-	print("Caliber: "..math.Round(caliber,3).."mm")
+--	print("Type: "..Type)
+--	print("Penetration: "..math.Round(maxPenetration,3).."mm")
+--	print("Caliber: "..math.Round(caliber,3).."mm")
 
 	local ACE_ArmorResolution = MatData["ArmorResolution"]
 	HitRes = ACE_ArmorResolution( Entity, armor, losArmor, losArmorHealth, maxPenetration, FrArea, caliber, damageMult, Type)

--- a/lua/acf/server/sv_acfbase.lua
+++ b/lua/acf/server/sv_acfbase.lua
@@ -205,6 +205,11 @@ function ACF_CalcDamage( Entity , Energy , FrArea , Angle , Type) --y=-5/16x + b
 	-- Projectile caliber. Messy, function signature
 	local caliber = 20 * (FrArea ^ (1 / ACF.PenAreaMod) / 3.1416) ^ 0.5
 
+	--Nifty shell information debugging.
+--	print("Type: "..Type)
+--	print("Penetration: "..math.Round(maxPenetration,3).."mm")
+--	print("Caliber: "..math.Round(caliber,3).."mm")
+
 	local ACE_ArmorResolution = MatData["ArmorResolution"]
 	HitRes = ACE_ArmorResolution( Entity, armor, losArmor, losArmorHealth, maxPenetration, FrArea, caliber, damageMult, Type)
 

--- a/lua/acf/server/sv_acfbase.lua
+++ b/lua/acf/server/sv_acfbase.lua
@@ -206,9 +206,9 @@ function ACF_CalcDamage( Entity , Energy , FrArea , Angle , Type) --y=-5/16x + b
 	local caliber = 20 * (FrArea ^ (1 / ACF.PenAreaMod) / 3.1416) ^ 0.5
 
 	--Nifty shell information debugging.
---	print("Type: "..Type)
---	print("Penetration: "..math.Round(maxPenetration,3).."mm")
---	print("Caliber: "..math.Round(caliber,3).."mm")
+	print("Type: "..Type)
+	print("Penetration: "..math.Round(maxPenetration,3).."mm")
+	print("Caliber: "..math.Round(caliber,3).."mm")
 
 	local ACE_ArmorResolution = MatData["ArmorResolution"]
 	HitRes = ACE_ArmorResolution( Entity, armor, losArmor, losArmorHealth, maxPenetration, FrArea, caliber, damageMult, Type)

--- a/lua/acf/server/sv_acfdamage.lua
+++ b/lua/acf/server/sv_acfdamage.lua
@@ -311,10 +311,20 @@ function ACF_Spall( HitPos , HitVec , Filter , KE , Caliber , Armour , Inflictor
 	if SpallMul > 0 and Caliber * 10 > UsedArmor and Caliber > 3 then
 
 		-- Normal spalling core
-		local TotalWeight = PI * (Caliber / 2) ^ 2 * math.max(UsedArmor, 30) * 150
-		local Spall = math.min(math.floor((Caliber - 3) * ACF.KEtoSpall * SpallMul * 1.33) * ACF.SpallMult, 24)
+		--For better consistency against light armor, spall no longer cares about the thickness of the armor but moreso the hole the cannon punches through and the energy it uses doing so.
+
+		--Weight factor variable. Affects both the weight of the spall and indirectly affects the caliber of the spall
+		--0.75 results in 11mm spall with a 120mm SBC
+		--15 results in 20mm spall
+		local WeightFactor = 15
+		
+		--Direct multiplier for spall velocity, used to fine-tune the spall penetration
+		local Velocityfactor = 300
+
+		local TotalWeight = PI * (Caliber / 2) ^ 2 * ArmorMul * WeightFactor
+		local Spall = math.min(math.floor((Caliber - 3) * ACF.KEtoSpall * SpallMul * 1.33) * ACF.SpallMult, 32)
 		local SpallWeight = TotalWeight / Spall * SpallMul
-		local SpallVel = (KE * 16 / SpallWeight) ^ 0.5 / Spall * SpallMul
+		local SpallVel = (KE * 16 / SpallWeight) ^ 0.5 / Spall * SpallMul * Velocityfactor
 		local SpallArea = (SpallWeight / 7.8) ^ 0.33
 		local SpallEnergy = ACF_Kinetic(SpallVel, SpallWeight, 800)
 
@@ -330,7 +340,7 @@ function ACF_Spall( HitPos , HitVec , Filter , KE , Caliber , Armour , Inflictor
 
 			ACE.Spall[Index] = {}
 			ACE.Spall[Index].start  = HitPos
-			ACE.Spall[Index].endpos = HitPos + (HitVec:GetNormalized() + VectorRand() / 3):GetNormalized() * math.max( SpallVel * 10, math.random(450,600) ) --I got bored of spall not going across the tank
+			ACE.Spall[Index].endpos = HitPos + (HitVec:GetNormalized() + VectorRand()* ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVel, 600 ) --Spall endtrace. Used to determine spread and the spall trace length. Only adjust the value in the max to determine the minimum distance spall will travel. 600 should be fine.
 			ACE.Spall[Index].filter = table.Copy(Filter)
 			ACE.Spall[Index].mins	= Vector(0,0,0)
 			ACE.Spall[Index].maxs	= Vector(0,0,0)

--- a/lua/acf/server/sv_acfdamage.lua
+++ b/lua/acf/server/sv_acfdamage.lua
@@ -317,7 +317,7 @@ function ACF_Spall( HitPos , HitVec , Filter , KE , Caliber , Armour , Inflictor
 		--0.75 results in 11mm spall with a 120mm SBC
 		--15 results in 20mm spall
 		local WeightFactor = 15
-		
+
 		--Direct multiplier for spall velocity, used to fine-tune the spall penetration
 		local Velocityfactor = 300
 
@@ -340,7 +340,7 @@ function ACF_Spall( HitPos , HitVec , Filter , KE , Caliber , Armour , Inflictor
 
 			ACE.Spall[Index] = {}
 			ACE.Spall[Index].start  = HitPos
-			ACE.Spall[Index].endpos = HitPos + (HitVec:GetNormalized() + VectorRand()* ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVel, 600 ) --Spall endtrace. Used to determine spread and the spall trace length. Only adjust the value in the max to determine the minimum distance spall will travel. 600 should be fine.
+			ACE.Spall[Index].endpos = HitPos + ( HitVec:GetNormalized() + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVel, 600 ) --Spall endtrace. Used to determine spread and the spall trace length. Only adjust the value in the max to determine the minimum distance spall will travel. 600 should be fine.
 			ACE.Spall[Index].filter = table.Copy(Filter)
 			ACE.Spall[Index].mins	= Vector(0,0,0)
 			ACE.Spall[Index].maxs	= Vector(0,0,0)

--- a/lua/acf/shared/rounds/roundheat.lua
+++ b/lua/acf/shared/rounds/roundheat.lua
@@ -233,7 +233,7 @@ function Round.propimpact( Index, Bullet, Target, HitNormal, HitPos, Bone )
 
 				table.insert( Bullet.Filter , Target )
 
-				ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , (Energy.Kinetic * HitRes.Loss + 0.2) * 64 , Bullet.CannonCaliber , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
+				ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , (Energy.Kinetic * HitRes.Loss + 0.2) , Bullet.CannonCaliber , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
 				Bullet.Flight = Bullet.Flight:GetNormalized() * math.sqrt(Energy.Kinetic * (1 - HitRes.Loss) * ((Bullet.NotFirstPen and ACF.HEATPenLayerMul) or 1) * 2000 / Bullet.ProjMass) * 39.37
 
 				return "Penetrated"

--- a/lua/acf/shared/rounds/roundheatfs.lua
+++ b/lua/acf/shared/rounds/roundheatfs.lua
@@ -221,7 +221,7 @@ function Round.propimpact( Index, Bullet, Target, HitNormal, HitPos, Bone )
 
 			if HitRes.Overkill > 0 then
 				table.insert( Bullet.Filter , Target )					--"Penetrate" (Ingoring the prop for the retry trace)
-				ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , (Energy.Kinetic * HitRes.Loss + 0.2) * 64 , Bullet.CannonCaliber * 2 , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
+				ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , (Energy.Kinetic * HitRes.Loss + 0.2) , Bullet.CannonCaliber * 2 , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
 				Bullet.Flight = Bullet.Flight:GetNormalized() * math.sqrt(Energy.Kinetic * (1 - HitRes.Loss) * ((Bullet.NotFirstPen and ACF.HEATPenLayerMul) or 1) * 2000 / Bullet.ProjMass) * 39.37
 
 				return "Penetrated"

--- a/lua/acf/shared/rounds/roundtheat.lua
+++ b/lua/acf/shared/rounds/roundtheat.lua
@@ -299,7 +299,7 @@ function Round.propimpact( Index, Bullet, Target, HitNormal, HitPos, Bone )
 			if HitRes.Overkill > 0 then
 
 				table.insert( Bullet.Filter , Target )				--"Penetrate" (Ingoring the prop for the retry trace)
-				ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , (Energy.Kinetic * HitRes.Loss + 0.2) * 64 , Bullet.CannonCaliber , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
+				ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , (Energy.Kinetic * HitRes.Loss + 0.2) , Bullet.CannonCaliber , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
 				Bullet.Flight = Bullet.Flight:GetNormalized() * math.sqrt(Energy.Kinetic * (1 - HitRes.Loss) * ((Bullet.NotFirstPen and ACF.HEATPenLayerMul) or 1) * 2000 / Bullet.ProjMass) * 39.37
 
 				return "Penetrated"

--- a/lua/acf/shared/rounds/roundtheatfs.lua
+++ b/lua/acf/shared/rounds/roundtheatfs.lua
@@ -260,7 +260,7 @@ function Round.propimpact( Index, Bullet, Target, HitNormal, HitPos, Bone )
 
 				table.insert( Bullet.Filter , Target )				--"Penetrate" (Ingoring the prop for the retry trace)
 
-				ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , (Energy.Kinetic * HitRes.Loss + 0.2) * 64 , Bullet.CannonCaliber , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
+				ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , (Energy.Kinetic * HitRes.Loss + 0.2) , Bullet.CannonCaliber , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
 				Bullet.Flight = Bullet.Flight:GetNormalized() * math.sqrt(Energy.Kinetic * (1 - HitRes.Loss) * 2000 / Bullet.ProjMass) * 39.37
 
 				return "Penetrated"

--- a/lua/autorun/acf_globals.lua
+++ b/lua/autorun/acf_globals.lua
@@ -149,7 +149,7 @@ ACF.ScaledEntsMax     = 5
 
 ---------------------------------- Ballistic config ----------------------------------
 
-ACF.Bullet            = {}	-- when ACF is loaded, this table holds bullets
+ACF.Bullet            = {} --When ACF is loaded, this table holds bullets
 ACF.CurBulletIndex    = 0	-- used to track where to insert bullets
 ACF.BulletIndexLimit  = 5000	-- The maximum number of bullets in flight at any one time TODO: fix the typo
 ACF.SkyboxGraceZone   = 100	-- grace zone for the high angle fire

--- a/lua/autorun/acf_globals.lua
+++ b/lua/autorun/acf_globals.lua
@@ -149,7 +149,7 @@ ACF.ScaledEntsMax     = 5
 
 ---------------------------------- Ballistic config ----------------------------------
 
-ACF.Bullet            = {} --When ACF is loaded, this table holds bullets
+ACF.Bullet			  = {} --When ACF is loaded, this table holds bullets
 ACF.CurBulletIndex    = 0	-- used to track where to insert bullets
 ACF.BulletIndexLimit  = 5000	-- The maximum number of bullets in flight at any one time TODO: fix the typo
 ACF.SkyboxGraceZone   = 100	-- grace zone for the high angle fire

--- a/lua/autorun/acf_globals.lua
+++ b/lua/autorun/acf_globals.lua
@@ -209,6 +209,14 @@ ACF.SlopeEffectFactor   = 1.1					-- Sloped armor effectiveness: armor / cos(ang
 ACF.Spalling            = 1
 ACF.SpallMult           = 1
 
+
+--Math in globals????
+
+--UNLESS YOU WANT SPALL TO FLY BACKWARDS, BE ABSOLUTELY SURE TO MAKE SURE THIS VECTOR LENGTH IS LESS THAN 1
+--The vector controls the spread pattern. The multiplier adjusts the tightness of the spread cone. ABSOLUTELY DO NOT MAKE THE MULTIPLIER MORE THAN 1. A Vector of 1,1,0.5. Results in half the vertical spall spread
+ACF.SpallingDistribution = Vector(1,1,0.5):GetNormalized() * 0.45 
+
+
 ---------------------------------- Particle colors  ----------------------------------
 
 ACE.DustMaterialColor = {


### PR DESCRIPTION
Completely reworked the penetration and weight distribution of spall.
-The penetration was derived for a 20mm MG for a 120mm cannon.
-Added simple variables to adjust the spall distribution patterns and to tune spall penetration.
-Moved spalling away from armor plate thickness making it more useful when shooting light vehicles.